### PR TITLE
#105 Add plan-mode authoring contract for task/bug body drafting

### DIFF
--- a/plugins/workflow/authoring/common/bug-authoring.md
+++ b/plugins/workflow/authoring/common/bug-authoring.md
@@ -40,6 +40,9 @@ Optional sections:
 - `Environment` — version, browser, OS, tenant, data shape, feature flags, or deployment context.
 - `Change Plan` — forward-looking scope fence naming files, packages, APIs, or migration steps expected to change.
 - `Interface Contracts` — contracts the fix consumes or restores.
+- `Out of Scope` — work explicitly excluded from this issue. See `./issue-body.md`.
+- `Alternatives Considered` — design options evaluated but not chosen. See `./issue-body.md`.
+- `Risks` — technical or operational risks specific to this work. See `./issue-body.md`.
 - `Resume` — current-state snapshot while mid-flight. See `./issue-body.md`.
 - `Why Discarded` — reason when discarded. See `./issue-body.md`.
 

--- a/plugins/workflow/authoring/common/issue-body.md
+++ b/plugins/workflow/authoring/common/issue-body.md
@@ -29,6 +29,9 @@ Common reusable section names for issue-backed items:
 - `Description`
 - `Acceptance Criteria`
 - `Unit Test Strategy`
+- `Out of Scope`
+- `Alternatives Considered`
+- `Risks`
 - `Open Questions`
 - `Related`
 - `Resume`
@@ -83,6 +86,36 @@ Rewrite the `Resume` section in place. Do not preserve history there.
 Use when an issue is intentionally abandoned and provider status alone does not explain why.
 
 The section should hold one dated bullet per reason, citing the cause when relevant. Provider files define the exact list and link form.
+
+## `Out of Scope` section
+
+Purpose: name what the issue explicitly does not cover.
+
+Use when the issue title or `Description` could be read as covering broader work, or when a related concern was deliberately deferred to a follow-up.
+
+Do not use when the body is small enough that scope is obvious from `Description` and `Change Plan`, or when the only deferred item is a generic disclaimer with no concrete follow-up.
+
+List one deferred item per bullet with a short reason or link to the follow-up.
+
+## `Alternatives Considered` section
+
+Purpose: record design or implementation options that were evaluated but not chosen, with the rejection reason.
+
+Use when the chosen approach is non-obvious and a reviewer is likely to suggest one of the rejected options.
+
+Do not use when no real alternatives were considered, or when the reasoning belongs in a curated knowledge page (create or update that page instead).
+
+List one alternative per bullet with the rejection reason. Do not re-litigate the accepted decision here.
+
+## `Risks` section
+
+Purpose: name technical risks, regression hazards, or operational concerns specific to this issue.
+
+Use when the change touches load-bearing code, migrations, contracts, or behavior with non-trivial blast radius, and the risk is not already covered by `Acceptance Criteria` or the test strategy.
+
+Do not use when the change is small and routine, or when the risk is already represented by an `Open Questions` entry or test scenario.
+
+List one risk per bullet with the mitigation or detection plan when known.
 
 ## Relationship lists
 

--- a/plugins/workflow/authoring/common/plan-mode-authoring.md
+++ b/plugins/workflow/authoring/common/plan-mode-authoring.md
@@ -1,0 +1,74 @@
+# Plan Mode Body Drafting
+
+Use plan mode to converge on a `task` or `bug` issue body before invoking the
+provider write. Plan mode forces context gathering before action, blocks file
+edits until alignment, and produces a single approval gate — the agreed plan
+text becomes the body of the issue.
+
+Companion contracts:
+
+- `./issue-body.md`
+- `./task-authoring.md` (for `task`)
+- `./bug-authoring.md` (for `bug`)
+
+## When to use
+
+Use plan mode when the issue body needs converged content for a planned
+implementation or fix.
+
+Skip plan mode for:
+
+- Exploratory items (`spike`, `research`) where the body grows after the
+  issue is created.
+- Trivial updates that touch a single field or short bullet.
+- Coordination items (`epic`, `review`) where the body coordinates other
+  work rather than describing implementation.
+
+## Skeleton
+
+Enter plan mode with the required body skeleton in place, then fill each
+section through conversation. Add optional sections from `./issue-body.md`
+(`Out of Scope`, `Alternatives Considered`, `Risks`, `Interface Contracts`,
+`Environment` for bug) only when content for them surfaces.
+
+`task` required sections (`./task-authoring.md`):
+
+- `Description`
+- `Change Plan` (when expected scope is known)
+- `Unit Test Strategy`
+- `Acceptance Criteria`
+
+`bug` required sections (`./bug-authoring.md`):
+
+- `Description`
+- `Reproduction`
+- `Unit Test Strategy`
+- `Acceptance Criteria`
+
+## Content routing
+
+Route plan-mode-style content to the right section so it does not collapse
+into `Description`:
+
+| Plan-mode content | Target section |
+| --- | --- |
+| Motivation, problem, why now | `Description` |
+| High-level approach | `Description` |
+| Files, packages, APIs to touch | `Change Plan` |
+| Test scenarios, isolation, locations | `Unit Test Strategy` |
+| Observable completion conditions | `Acceptance Criteria` |
+| Reproduction steps (bug) | `Reproduction` |
+| Deferred or excluded work | `Out of Scope` |
+| Alternatives evaluated and rejected | `Alternatives Considered` |
+| Regression hazards, blast radius concerns | `Risks` |
+| Pending decisions, input requests | `Open Questions` |
+
+If content does not fit any section above, prefer a new well-named section
+over squeezing it into `Description`. Section taxonomy lives in
+`./issue-body.md`.
+
+## Handoff
+
+After plan approval, the agreed plan text is the body. Write it to the body
+file path verbatim, then invoke the provider publish or update flow with
+that body file.

--- a/plugins/workflow/authoring/common/task-authoring.md
+++ b/plugins/workflow/authoring/common/task-authoring.md
@@ -70,6 +70,9 @@ Optional sections:
 
 - `Change Plan` — forward-looking scope fence naming files, packages, APIs, or migration steps expected to change.
 - `Interface Contracts` — contracts this task consumes or provides.
+- `Out of Scope` — work explicitly excluded from this issue. See `./issue-body.md`.
+- `Alternatives Considered` — design options evaluated but not chosen. See `./issue-body.md`.
+- `Risks` — technical or operational risks specific to this work. See `./issue-body.md`.
 - `Resume` — current-state snapshot while mid-flight. See `./issue-body.md`.
 - `Why Discarded` — reason when discarded. See `./issue-body.md`.
 

--- a/plugins/workflow/authoring/providers/github-issue-bug-authoring.md
+++ b/plugins/workflow/authoring/providers/github-issue-bug-authoring.md
@@ -29,6 +29,9 @@ Common optional sections are defined by `../common/bug-authoring.md` and `../com
 - `## Environment`
 - `## Change Plan`
 - `## Interface Contracts`
+- `## Out of Scope`
+- `## Alternatives Considered`
+- `## Risks`
 - `## Resume`
 - `## Why Discarded`
 

--- a/plugins/workflow/authoring/providers/github-issue-task-authoring.md
+++ b/plugins/workflow/authoring/providers/github-issue-task-authoring.md
@@ -27,6 +27,9 @@ Common optional sections are defined by `../common/task-authoring.md` and `../co
 
 - `## Change Plan`
 - `## Interface Contracts`
+- `## Out of Scope`
+- `## Alternatives Considered`
+- `## Risks`
 - `## Resume`
 - `## Why Discarded`
 

--- a/plugins/workflow/authoring/providers/jira-issue-bug-authoring.md
+++ b/plugins/workflow/authoring/providers/jira-issue-bug-authoring.md
@@ -29,6 +29,9 @@ Common optional sections are defined by `../common/bug-authoring.md` and `../com
 - `h2. Environment`
 - `h2. Change Plan`
 - `h2. Interface Contracts`
+- `h2. Out of Scope`
+- `h2. Alternatives Considered`
+- `h2. Risks`
 - `h2. Resume`
 - `h2. Why Discarded`
 

--- a/plugins/workflow/authoring/providers/jira-issue-task-authoring.md
+++ b/plugins/workflow/authoring/providers/jira-issue-task-authoring.md
@@ -27,6 +27,9 @@ Common optional sections are defined by `../common/task-authoring.md` and `../co
 
 - `h2. Change Plan`
 - `h2. Interface Contracts`
+- `h2. Out of Scope`
+- `h2. Alternatives Considered`
+- `h2. Risks`
 - `h2. Resume`
 - `h2. Why Discarded`
 

--- a/plugins/workflow/scripts/authoring_resolver.py
+++ b/plugins/workflow/scripts/authoring_resolver.py
@@ -38,6 +38,8 @@ AUTHORING_SCOPES = {"content", "comment"}
 
 PRD_COMPONENT_TYPES = {"context", "usecase", "nfr", "spec", "domain"}
 
+PLAN_MODE_TYPES = {"task", "bug"}
+
 ISSUE_PROVIDER_FILES = {
     "github": "providers/github-issue-convention.md",
     "jira": "providers/jira-issue-convention.md",
@@ -222,6 +224,8 @@ def resolve_authoring(
     if normalized_type in PRD_COMPONENT_TYPES:
         parts.append("common/prd-authoring.md")
     parts.append(f"common/{normalized_type}-authoring.md")
+    if normalized_role == "issue" and normalized_type in PLAN_MODE_TYPES:
+        parts.append("common/plan-mode-authoring.md")
 
     if normalized_role == "issue" and normalized_provider in ISSUE_PROVIDER_FILES:
         parts.append(ISSUE_PROVIDER_FILES[normalized_provider])

--- a/plugins/workflow/tests/test_authoring_resolver.py
+++ b/plugins/workflow/tests/test_authoring_resolver.py
@@ -206,6 +206,36 @@ def test_require_config_fails_when_missing(tmp_path: Path) -> None:
         resolve_authoring("task", project=tmp_path, require_config=True)
 
 
+@pytest.mark.parametrize("artifact_type", ["task", "bug"])
+def test_implementation_types_include_plan_mode_authoring(artifact_type: str) -> None:
+    resolution = resolve_authoring(artifact_type)
+    assert "common/plan-mode-authoring.md" in _rel_paths(resolution.files)
+
+
+@pytest.mark.parametrize(
+    "artifact_type,role",
+    [
+        ("spike", None),
+        ("epic", None),
+        ("review", None),
+        ("research", "issue"),
+        ("usecase", "issue"),
+        ("spec", None),
+        ("architecture", None),
+    ],
+)
+def test_non_implementation_types_exclude_plan_mode_authoring(
+    artifact_type: str, role: str | None
+) -> None:
+    resolution = resolve_authoring(artifact_type, role=role)
+    assert "common/plan-mode-authoring.md" not in _rel_paths(resolution.files)
+
+
+def test_task_comment_scope_excludes_plan_mode_authoring() -> None:
+    resolution = resolve_authoring("task", role="issue", provider="github", scope="comment")
+    assert "common/plan-mode-authoring.md" not in _rel_paths(resolution.files)
+
+
 def test_authoring_path_classification_uses_plugin_authoring_root(tmp_path: Path) -> None:
     authoring_file = _PLUGIN_ROOT / "authoring" / "common" / "task-authoring.md"
     outside_file = tmp_path / "task-authoring.md"


### PR DESCRIPTION
## Summary

- Add `Out of Scope`, `Alternatives Considered`, `Risks` as known optional body sections in `authoring/common/issue-body.md` with purpose / when-to-use / when-not-to-use definitions.
- Introduce `authoring/common/plan-mode-authoring.md` — provider-neutral plan-mode body drafting contract (when to use, `task`/`bug` skeletons, content routing table, handoff).
- Wire the contract into `authoring_resolver.py` so it loads lazily for `role=issue`, `type in {task, bug}`, `scope=content`. SessionStart context budget unchanged.
- Enumerate the three new optional sections in `common/task-authoring.md`, `common/bug-authoring.md`, and the github/jira `*-issue-task-authoring.md` / `*-issue-bug-authoring.md` provider bindings (names only; semantics stay in `issue-body.md`).

Refs #105.

## Test plan

- [x] `pytest plugins/workflow/tests/test_authoring_resolver.py` — 44 tests pass including 3 new (task/bug inclusion, non-impl exclusion, comment-scope exclusion).
- [x] Sanity: `\$WORKFLOW authoring_resolver.py --type task --json` includes `common/plan-mode-authoring.md`.
- [x] Sanity: `--type spike` and `--type task --scope comment` exclude it.