### PR TITLE
#128 Add Jira post-create relationship-failure regression test

### DIFF
--- a/plugins/workflow/tests/test_workflow_cache_issue_drafts.py
+++ b/plugins/workflow/tests/test_workflow_cache_issue_drafts.py
@@ -108,11 +108,14 @@ commit_refs:
     )
 
 
-def _write_jira_config(project: Path) -> None:
+def _write_jira_config(
+    project: Path,
+    *,
+    relationship_mappings: dict[str, dict[str, str]] | None = None,
+) -> None:
     config_path = project / ".workflow" / "config.yml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(
-        """
+    text = """
 version: 1
 providers:
   issues:
@@ -122,12 +125,18 @@ providers:
     api_version: 2
     project: TEST
     issue_type: Task
-  knowledge:
+""".lstrip()
+    if relationship_mappings:
+        text += "    relationship_mappings:\n"
+        for name, mapping in relationship_mappings.items():
+            text += f"      {name}:\n"
+            for key, value in mapping.items():
+                text += f"        {key}: {value}\n"
+    text += """  knowledge:
     kind: github
 issue_id_format: jira
-""".lstrip(),
-        encoding="utf-8",
-    )
+"""
+    config_path.write_text(text, encoding="utf-8")
 
 
 def _repo() -> GitHubRepository:
@@ -1055,6 +1064,97 @@ def test_jira_publish_fails_fast_when_relationship_mapping_missing(tmp_path: Pat
     assert runner.requests == []
     assert body_file.exists()
     assert stdout.getvalue() == ""
+
+
+class JiraPublishRelationshipFailureRunner(JiraFakeRunner):
+    """Mirror of GitHub's post-create relationship failure shape for Jira.
+
+    The Jira `create` and `create_issue_link` POSTs both hit curl with the
+    same outer argv (``_jira_write_args()``); the destination URL lives in
+    the curl --config stdin. This subclass routes the create POST to the
+    success response and lets the link POST fall through to the default
+    ``returncode=127`` raise that trips ``_publish_issue``'s
+    ``except Exception`` handler.
+    """
+
+    def __call__(self, request: CommandRequest) -> CommandResult:
+        if request.args == _jira_write_args() and "/issueLink" in (request.input_text or ""):
+            self.requests.append(request)
+            return CommandResult(
+                request=request,
+                returncode=127,
+                stderr="unexpected: issueLink dispatch (intended to fail)",
+            )
+        return super().__call__(request)
+
+
+def test_jira_publish_preserves_body_on_relationship_failure(tmp_path: Path) -> None:
+    _write_jira_config(
+        tmp_path,
+        relationship_mappings={"related": {"link_type": "Relates", "direction": "outward"}},
+    )
+    body_file = _write_body_file(tmp_path, "Body.\n")
+    issue_url = "https://jira.example.test/rest/api/2/issue/TEST-1234"
+    remote_links_url = "https://jira.example.test/rest/api/2/issue/TEST-1234/remotelink"
+
+    runner = JiraPublishRelationshipFailureRunner(
+        {
+            _jira_write_args(): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps({"id": "10001", "key": "TEST-1234"}),
+            ),
+            _jira_curl_get_args(issue_url): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps(_jira_issue_payload()),
+            ),
+            _jira_curl_get_args(remote_links_url): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps([]),
+            ),
+        }
+    )
+    stdout = io.StringIO()
+
+    code = jira_issue_drafts_main(
+        [
+            "--project",
+            str(tmp_path),
+            "publish",
+            "--type",
+            "task",
+            "--title",
+            "Published Jira issue",
+            "--body-file",
+            str(body_file),
+            "--related",
+            "TEST-99",
+        ],
+        stdout=stdout,
+        runner=runner,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert code == 1
+    assert payload["issue"] == "TEST-1234"
+    assert payload["body_file_removed"] is False
+    assert payload["body_file"] == str(body_file)
+    assert body_file.exists()
+    relationships = payload["relationships"]
+    assert relationships["status"] == "failed"
+    assert relationships["intent"] == {"related_add": ["TEST-99"]}
+    # Guard: the create POST must actually fire so a future regression that
+    # short-circuits in the pre-create validator (the branch already covered
+    # by test_jira_publish_fails_fast_when_relationship_mapping_missing) does
+    # not silently pass this post-create regression test.
+    assert runner.requests[0].args == _jira_write_args()
+    link_writes = [
+        r for r in runner.requests
+        if r.args == _jira_write_args() and "/issueLink" in (r.input_text or "")
+    ]
+    assert len(link_writes) == 1
 
 
 def test_jira_publish_epic_with_post_create_epic_link_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Closes #128.
- The unified-backend refactor already fixed the original orphan-body bug in both providers (body unlink is gated behind relationship-apply success; failure envelope carries the new issue ref plus unapplied intent; GitHub exits non-zero like Jira). GitHub has a regression test for the post-create failure branch; the Jira side had no equivalent, so the original bug could silently return there.
- This PR mirrors the GitHub regression onto Jira so the post-create `apply_relationships` failure branch is exercised end-to-end via `jira_issue_drafts_main`. No production code changes.

## What changed

- `plugins/workflow/tests/test_workflow_cache_issue_drafts.py`:
  - Extended `_write_jira_config` with an optional `relationship_mappings` kwarg so the pre-create validator can be satisfied for `--related`.
  - Added `JiraPublishRelationshipFailureRunner`, a small `JiraFakeRunner` subclass that disambiguates the create POST from the `create_issue_link` POST by URL substring in the curl `--config` stdin (both share the same outer argv `_jira_write_args()`). The create POST returns the success canned response; the `/issueLink` POST falls through to the default `returncode=127` so the `except Exception` handler in `_publish_issue` fires.
  - Added `test_jira_publish_preserves_body_on_relationship_failure`, mirroring the assertion shape of `test_github_publish_preserves_body_on_relationship_failure`. The test asserts the failure-envelope contract (exit code 1, body file preserved on disk, `body_file_removed is False`, intent echoed under `relationships.intent`) and includes a guard that the create POST actually fires and exactly one `/issueLink` write was attempted — so a future regression that short-circuits in the pre-create validator (already covered by `test_jira_publish_fails_fast_when_relationship_mapping_missing`) cannot silently pass this post-create test.

## AC evidence

- AC1 (Jira post-create regression test added): new `test_jira_publish_preserves_body_on_relationship_failure` exercises the post-create `apply_relationships` failure branch end-to-end via `jira_issue_drafts_main`. Asserts `code == 1`, `payload["issue"] == "TEST-1234"`, `payload["body_file_removed"] is False`, `body_file.exists()`, `payload["relationships"]["status"] == "failed"`, and `payload["relationships"]["intent"] == {"related_add": ["TEST-99"]}`. Guard assertions on `runner.requests[0].args == _jira_write_args()` and the count of `/issueLink` writes prevent a silent fall-back into the pre-create validator path.
- AC2 (follows existing helpers / conventions): the new test reuses `_jira_write_args`, `_jira_curl_get_args`, `_jira_issue_payload`, and `_write_jira_config` (extended with a kwarg-with-default that follows the surrounding pattern). The new `JiraPublishRelationshipFailureRunner` is a `JiraFakeRunner` subclass placed as a sibling helper class, mirroring the existing `GitHubAppendCommentRunner` / `GitHubUpdateIssueRunner` pattern in the same file.
- AC3 (full suite green): `uv run --with pytest --with python-frontmatter --with PyYAML pytest plugins/workflow/tests` → `556 passed in 2.81s` after the change.

## Test plan

- [x] `uv run --with pytest --with python-frontmatter --with PyYAML pytest plugins/workflow/tests -k test_jira_publish_preserves_body_on_relationship_failure -vv` — passes
- [x] `uv run --with pytest --with python-frontmatter --with PyYAML pytest plugins/workflow/tests` — 556 passed