### PR TITLE
#99 Project issue assignee into snapshot frontmatter (Jira + GitHub)

### DIFF
--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/workflow/.codex-plugin/plugin.json
+++ b/plugins/workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/workflow/scripts/issue/github/cache.py
+++ b/plugins/workflow/scripts/issue/github/cache.py
@@ -380,6 +380,7 @@ class GitHubIssueCache:
             "title": str(issue.get("title") or ""),
             "state": _normalize_state(issue.get("state")),
             "state_reason": _normalize_state_reason(issue.get("stateReason") or issue.get("state_reason")),
+            "assignees": _github_assignees(issue.get("assignees")),
             "labels": _label_names(issue.get("labels")),
             "updated_at": updated_at,
             "fetched_at": now,
@@ -734,6 +735,42 @@ def _author_login(value: Any) -> str:
     if value:
         return str(value)
     return "unknown"
+
+
+def _github_person_display_name(value: Any) -> str | None:
+    """Resolve the best GitHub user display name from an assignee mapping.
+
+    GitHub user objects always carry ``login``; ``name`` is optional and
+    only populated when the user has set a public display name. Prefer
+    ``name`` when present so the frontmatter is human-friendly, fall back
+    to ``login`` otherwise. Returns ``None`` when the input is not a
+    mapping or carries neither key with a truthy value.
+    """
+
+    if isinstance(value, Mapping):
+        for key in ("name", "login"):
+            raw = value.get(key)
+            if raw:
+                return str(raw)
+    return None
+
+
+def _github_assignees(value: Any) -> list[str]:
+    """Project a GitHub assignees list into resolved display names.
+
+    Preserves provider order and skips entries that resolve to ``None``
+    (no ``name`` and no ``login``). Returns ``[]`` for missing or
+    non-list inputs so the frontmatter always carries a list.
+    """
+
+    if not isinstance(value, list):
+        return []
+    names: list[str] = []
+    for item in value:
+        resolved = _github_person_display_name(item)
+        if resolved is not None:
+            names.append(resolved)
+    return names
 
 
 def _latest_comment_timestamp(comments: list[Mapping[str, Any]]) -> str | None:

--- a/plugins/workflow/scripts/issue/jira/cache.py
+++ b/plugins/workflow/scripts/issue/jira/cache.py
@@ -29,7 +29,7 @@ from issue.jira.relationships import (
     filter_jira_payload,
     normalize_jira_data_center_issue,
 )
-from issue.jira.snapshot import render_jira_snapshot
+from issue.jira.snapshot import _jira_person_display_name, render_jira_snapshot
 from workflow_jira_data_center_client import JiraDataCenterSite
 
 
@@ -302,12 +302,10 @@ def _mapping_list(value: Any) -> list[Mapping[str, Any]]:
 
 
 def _comment_author_name(value: Any) -> str:
-    if isinstance(value, Mapping):
-        for key in ("displayName", "name", "key", "accountId"):
-            raw = value.get(key)
-            if raw:
-                return str(raw)
-    if value:
+    resolved = _jira_person_display_name(value)
+    if resolved is not None:
+        return resolved
+    if value and not isinstance(value, Mapping):
         return str(value)
     return "unknown"
 

--- a/plugins/workflow/scripts/issue/jira/relationships.py
+++ b/plugins/workflow/scripts/issue/jira/relationships.py
@@ -36,6 +36,12 @@ def normalize_jira_data_center_issue(
         remote_links=remote_links,
         relationship_mappings=relationship_mappings,
     )
+    raw_assignee = fields.get("assignee")
+    assignee = (
+        {str(akey): avalue for akey, avalue in raw_assignee.items()}
+        if isinstance(raw_assignee, Mapping)
+        else None
+    )
     payload: dict[str, Any] = {
         "issue": key,
         "key": key,
@@ -45,6 +51,7 @@ def normalize_jira_data_center_issue(
         "state": _normalize_optional(status.get("name")) or "unknown",
         "stateReason": _normalize_optional(status_category.get("key")),
         "labels": [str(label) for label in fields.get("labels") or [] if label is not None],
+        "assignee": assignee,
         "createdAt": _normalize_optional(fields.get("created")),
         "updatedAt": _normalize_optional(fields.get("updated")),
         "url": f"{site.base_url}/browse/{key}",

--- a/plugins/workflow/scripts/issue/jira/snapshot.py
+++ b/plugins/workflow/scripts/issue/jira/snapshot.py
@@ -47,6 +47,7 @@ def build_jira_snapshot_frontmatter(
         "title": str(issue.get("title") or ""),
         "state": _normalize_optional(issue.get("state")),
         "state_reason": _normalize_optional(issue.get("stateReason")),
+        "assignee": _jira_person_display_name(issue.get("assignee")),
         "labels": [str(label) for label in issue.get("labels") or []],
         "updated_at": updated_at,
         "fetched_at": fetched_at,
@@ -180,6 +181,24 @@ def _compact_unmapped_issue_links(value: Any) -> list[dict[str, Any]]:
         entry["target"] = target
         entries.append(entry)
     return entries
+
+
+def _jira_person_display_name(value: Any) -> str | None:
+    """Resolve the best Jira person display name from a user mapping.
+
+    Mirrors the fallback chain Jira's REST API documents for user objects:
+    ``displayName`` is preferred, then ``name`` (Data Center username),
+    then ``key``, then ``accountId`` (Cloud). Returns ``None`` when the
+    input is not a mapping or carries none of these keys with a truthy
+    value.
+    """
+
+    if isinstance(value, Mapping):
+        for key in ("displayName", "name", "key", "accountId"):
+            raw = value.get(key)
+            if raw:
+                return str(raw)
+    return None
 
 
 def _normalize_optional(value: Any) -> str | None:

--- a/plugins/workflow/scripts/workflow_github.py
+++ b/plugins/workflow/scripts/workflow_github.py
@@ -29,6 +29,7 @@ DEFAULT_ISSUE_FIELDS = (
     "stateReason",
     "body",
     "labels",
+    "assignees",
     "comments",
     "projectItems",
     "url",

--- a/plugins/workflow/tests/test_workflow_github_issue_cache.py
+++ b/plugins/workflow/tests/test_workflow_github_issue_cache.py
@@ -415,3 +415,93 @@ def test_corrupt_cache_entry_is_treated_as_miss(tmp_path: Path) -> None:
 
     assert response.payload["body"] == "Recovered body."
     assert cache.read_issue(repo(), 39)["body"] == "Recovered body."
+
+
+def test_default_issue_fields_includes_assignees() -> None:
+    """Guard against accidental removal of ``assignees`` from gh view fields.
+
+    Cache-refresh paths in ``issue/github/provider.py`` all call
+    ``view_issue`` with ``DEFAULT_ISSUE_FIELDS``, so dropping the key
+    would silently leave assignee data out of every cached snapshot.
+    """
+
+    assert "assignees" in DEFAULT_ISSUE_FIELDS
+
+
+def _payload_with_assignees(value: object) -> dict[str, object]:
+    payload = issue_payload()
+    payload["assignees"] = value
+    return payload
+
+
+def test_github_snapshot_frontmatter_includes_assignee_display_name(tmp_path: Path) -> None:
+    import frontmatter as frontmatter_lib
+
+    cache = GitHubIssueCache.for_project(tmp_path)
+    write = cache.write_issue_bundle(
+        repo(),
+        _payload_with_assignees([{"login": "alice", "name": "Alice Anderson"}]),
+        fetched_at="2026-05-13T12:34:56Z",
+    )
+
+    parsed = frontmatter_lib.loads(write.issue_file.read_text(encoding="utf-8"))
+    assert parsed.metadata["assignees"] == ["Alice Anderson"]
+
+
+def test_github_snapshot_frontmatter_assignees_fall_back_to_login(tmp_path: Path) -> None:
+    import frontmatter as frontmatter_lib
+
+    cache = GitHubIssueCache.for_project(tmp_path)
+    write = cache.write_issue_bundle(
+        repo(),
+        _payload_with_assignees([{"login": "alice"}]),
+        fetched_at="2026-05-13T12:34:56Z",
+    )
+
+    parsed = frontmatter_lib.loads(write.issue_file.read_text(encoding="utf-8"))
+    assert parsed.metadata["assignees"] == ["alice"]
+
+
+def test_github_snapshot_frontmatter_assignees_empty_when_unassigned(tmp_path: Path) -> None:
+    import frontmatter as frontmatter_lib
+
+    cache = GitHubIssueCache.for_project(tmp_path)
+
+    write_empty = cache.write_issue_bundle(
+        repo(),
+        _payload_with_assignees([]),
+        fetched_at="2026-05-13T12:34:56Z",
+    )
+    parsed_empty = frontmatter_lib.loads(write_empty.issue_file.read_text(encoding="utf-8"))
+    assert parsed_empty.metadata["assignees"] == []
+
+    payload_without_key = issue_payload()
+    payload_without_key.pop("assignees", None)
+    write_missing = cache.write_issue_bundle(
+        repo(),
+        payload_without_key,
+        fetched_at="2026-05-13T12:34:56Z",
+    )
+    parsed_missing = frontmatter_lib.loads(write_missing.issue_file.read_text(encoding="utf-8"))
+    assert "assignees" in parsed_missing.metadata
+    assert parsed_missing.metadata["assignees"] == []
+
+
+def test_github_snapshot_frontmatter_assignees_preserves_multiple(tmp_path: Path) -> None:
+    import frontmatter as frontmatter_lib
+
+    cache = GitHubIssueCache.for_project(tmp_path)
+    write = cache.write_issue_bundle(
+        repo(),
+        _payload_with_assignees(
+            [
+                {"login": "alice", "name": "Alice Anderson"},
+                {"login": "bob"},
+                {"login": "carol", "name": "Carol Carter"},
+            ]
+        ),
+        fetched_at="2026-05-13T12:34:56Z",
+    )
+
+    parsed = frontmatter_lib.loads(write.issue_file.read_text(encoding="utf-8"))
+    assert parsed.metadata["assignees"] == ["Alice Anderson", "bob", "Carol Carter"]

--- a/plugins/workflow/tests/test_workflow_issue_fields_jira.py
+++ b/plugins/workflow/tests/test_workflow_issue_fields_jira.py
@@ -282,6 +282,47 @@ def test_unassign_sets_fields_assignee_null(tmp_path: Path) -> None:
     assert any('\\"assignee\\":null' in str(request.input_text) for request in write_requests)
 
 
+def test_assign_refreshes_snapshot_frontmatter_with_new_assignee(tmp_path: Path) -> None:
+    """End-to-end: after assign, the refreshed issue.md shows the new assignee.
+
+    The writeback's `_refresh_cache` re-fetches the issue after the curl
+    write succeeds and replays `write_issue_bundle`, so the second
+    `curl_args(jira_issue_url())` response in the queue is what lands in
+    the on-disk snapshot. Returning an assignee-bearing payload there
+    asserts AC4 / AC1 hold without a manual `--cache-policy refresh`.
+    """
+
+    write_jira_config(tmp_path)
+    _seed_cache(tmp_path)
+    refreshed_payload = jira_issue_payload()
+    refreshed_fields = refreshed_payload["fields"]
+    assert isinstance(refreshed_fields, dict)
+    refreshed_fields["assignee"] = {"name": "alice", "displayName": "Alice Anderson"}
+
+    responses = _baseline_responses()
+    responses[curl_args(jira_issue_url())] = [
+        result(curl_args(jira_issue_url()), stdout=json.dumps(jira_issue_payload())),
+        result(curl_args(jira_issue_url()), stdout=json.dumps(refreshed_payload)),
+    ]
+    runner = FakeRunner(responses)
+
+    fields_payload(
+        project=tmp_path,
+        artifact_type="task",
+        verb="assign",
+        issue="TEST-1234",
+        user="alice",
+        runner=runner,
+    )
+
+    cache = JiraDataCenterIssueCache.for_project(tmp_path)
+    issue_md = cache.issue_file(jira_site(tmp_path), "TEST-1234")
+    import frontmatter as frontmatter_lib
+
+    parsed = frontmatter_lib.loads(issue_md.read_text(encoding="utf-8"))
+    assert parsed.metadata["assignee"] == "Alice Anderson"
+
+
 def test_reopen_uses_configured_reopen_transition(tmp_path: Path) -> None:
     write_jira_config(
         tmp_path,

--- a/plugins/workflow/tests/test_workflow_jira_issue_cache.py
+++ b/plugins/workflow/tests/test_workflow_jira_issue_cache.py
@@ -6,6 +6,7 @@ import sys
 from pathlib import Path
 
 import frontmatter as frontmatter_lib
+import pytest
 
 _PLUGIN_ROOT = Path(__file__).resolve().parent.parent
 _SCRIPTS_DIR = _PLUGIN_ROOT / "scripts"
@@ -13,7 +14,11 @@ if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
 from workflow_jira_data_center_client import JiraDataCenterSite  # noqa: E402
-from issue.jira.cache import JiraDataCenterIssueCache, is_jira_issue_cache_body_path  # noqa: E402
+from issue.jira.cache import (  # noqa: E402
+    JiraDataCenterIssueCache,
+    _comment_author_name,
+    is_jira_issue_cache_body_path,
+)
 
 
 def jira_site() -> JiraDataCenterSite:
@@ -115,3 +120,100 @@ def test_jira_write_issue_bundle_response_omits_internal_json_paths(tmp_path: Pa
     )
 
     assert set(written) == {"issue_dir", "issue_file"}
+
+
+def _payload_with_assignee(assignee: object) -> dict[str, object]:
+    payload = _jira_issue_payload("Open")
+    fields = payload["fields"]
+    assert isinstance(fields, dict)
+    fields["assignee"] = assignee
+    return payload
+
+
+def test_snapshot_frontmatter_includes_assignee_display_name(tmp_path: Path) -> None:
+    cache = JiraDataCenterIssueCache.for_project(tmp_path)
+    site = jira_site()
+
+    cache.write_issue_bundle(
+        site,
+        _payload_with_assignee({"displayName": "Alice Anderson", "name": "alice"}),
+        fetched_at="2026-05-15T10:00:00.000+0900",
+    )
+
+    parsed = frontmatter_lib.loads(cache.issue_file(site, "TEST-1234").read_text(encoding="utf-8"))
+    assert parsed.metadata["assignee"] == "Alice Anderson"
+
+
+@pytest.mark.parametrize(
+    ("assignee_field", "expected"),
+    [
+        (
+            {"displayName": "Alice Anderson", "name": "alice", "key": "alice-key", "accountId": "acc-1"},
+            "Alice Anderson",
+        ),
+        ({"name": "alice", "key": "alice-key", "accountId": "acc-1"}, "alice"),
+        ({"key": "alice-key", "accountId": "acc-1"}, "alice-key"),
+        ({"accountId": "acc-1"}, "acc-1"),
+    ],
+)
+def test_snapshot_frontmatter_assignee_falls_back_through_keys(
+    tmp_path: Path,
+    assignee_field: dict[str, object],
+    expected: str,
+) -> None:
+    cache = JiraDataCenterIssueCache.for_project(tmp_path)
+    site = jira_site()
+
+    cache.write_issue_bundle(
+        site,
+        _payload_with_assignee(assignee_field),
+        fetched_at="2026-05-15T10:00:00.000+0900",
+    )
+
+    parsed = frontmatter_lib.loads(cache.issue_file(site, "TEST-1234").read_text(encoding="utf-8"))
+    assert parsed.metadata["assignee"] == expected
+
+
+def test_snapshot_frontmatter_assignee_is_null_when_unassigned(tmp_path: Path) -> None:
+    cache = JiraDataCenterIssueCache.for_project(tmp_path)
+    site = jira_site()
+
+    cache.write_issue_bundle(
+        site,
+        _payload_with_assignee(None),
+        fetched_at="2026-05-15T10:00:00.000+0900",
+    )
+
+    parsed = frontmatter_lib.loads(cache.issue_file(site, "TEST-1234").read_text(encoding="utf-8"))
+    assert "assignee" in parsed.metadata
+    assert parsed.metadata["assignee"] is None
+
+
+def test_existing_snapshot_payload_still_renders_without_assignee_field(tmp_path: Path) -> None:
+    cache = JiraDataCenterIssueCache.for_project(tmp_path)
+    site = jira_site()
+
+    payload = _jira_issue_payload("Open")
+    fields = payload["fields"]
+    assert isinstance(fields, dict)
+    assert "assignee" not in fields
+
+    cache.write_issue_bundle(
+        site,
+        payload,
+        fetched_at="2026-05-15T10:00:00.000+0900",
+    )
+
+    parsed = frontmatter_lib.loads(cache.issue_file(site, "TEST-1234").read_text(encoding="utf-8"))
+    assert "assignee" in parsed.metadata
+    assert parsed.metadata["assignee"] is None
+
+
+def test_comment_author_name_still_uses_shared_jira_display_name_fallback() -> None:
+    assert _comment_author_name({"displayName": "Alice", "name": "alice"}) == "Alice"
+    assert _comment_author_name({"name": "alice"}) == "alice"
+    assert _comment_author_name({"key": "alice-key"}) == "alice-key"
+    assert _comment_author_name({"accountId": "acc-1"}) == "acc-1"
+    assert _comment_author_name(None) == "unknown"
+    assert _comment_author_name({}) == "unknown"
+    assert _comment_author_name("alice") == "alice"


### PR DESCRIPTION
## Summary

The assignee write surface landed in #98 on both Jira and GitHub, but no user-visible projection surfaced who's currently assigned. This change projects the assignee into each provider's `issue.md` YAML frontmatter so the cached snapshot round-trips post-write state without a manual `--cache-policy refresh`.

- **Jira**: `normalize_jira_data_center_issue` now carries `fields.assignee` through as a raw mapping; `build_jira_snapshot_frontmatter` emits an `assignee` key using a new shared `_jira_person_display_name` helper (`displayName -> name -> key -> accountId`). `_comment_author_name` becomes a thin wrapper over the helper so the fallback chain has exactly one definition.
- **GitHub**: `DEFAULT_ISSUE_FIELDS` gains `assignees`, so every cache-refresh path (including the write-side auto-refresh after assign/unassign) populates the field. `write_issue_bundle` emits an `assignees` list-valued key via a new `_github_assignees` helper that resolves each entry through `_github_person_display_name` (`name -> login`). GitHub supports multiple assignees, so the field is plural; unassigned issues render `[]`.
- **Both**: no separate `metadata.yml` file is introduced — snapshot frontmatter (already machine-readable via `python-frontmatter`) absorbs that role, preserving the existing `test_jira_write_issue_bundle_does_not_emit_metadata_file` guarantee.
- Bumps the workflow plugin to `0.5.1` in lockstep across `plugins/workflow/.claude-plugin/plugin.json` and `plugins/workflow/.codex-plugin/plugin.json`.

The body of #99 referenced pre-restructure paths (`workflow_jira_issue_snapshot.py`, `workflow_jira_issue_cache.py`, `_author_name`) and the now-disproved "optional `metadata.yml`" target. The implementer plan absorbed those drift corrections rather than writing them back. The user expanded #99's original Jira-only scope to also project GitHub assignees in the same shipping unit.

## Test plan

- [x] `uv run --with pytest --with python-frontmatter --with PyYAML pytest plugins/workflow/tests` — 575 passed (561 baseline + 14 new).
- [x] AC1 (Jira): `test_snapshot_frontmatter_includes_assignee_display_name`, `test_snapshot_frontmatter_assignee_is_null_when_unassigned`.
- [x] AC1 (GitHub parallel): `test_github_snapshot_frontmatter_includes_assignee_display_name`, `test_github_snapshot_frontmatter_assignees_empty_when_unassigned`.
- [x] AC2 (Jira `displayName -> name -> key -> accountId` fallback): parametrized `test_snapshot_frontmatter_assignee_falls_back_through_keys` plus `test_comment_author_name_still_uses_shared_jira_display_name_fallback` for the single-definition guarantee.
- [x] AC2 (GitHub `name -> login` fallback): `test_github_snapshot_frontmatter_assignees_fall_back_to_login`.
- [x] AC3 (no `metadata.yml`): existing `test_jira_write_issue_bundle_does_not_emit_metadata_file` stays green; YAML frontmatter is the machine-readable surface on both sides.
- [x] AC4 (writeback auto-refresh, no manual `--cache-policy refresh`): `test_assign_refreshes_snapshot_frontmatter_with_new_assignee` exercises the Jira `_refresh_cache` path end-to-end; the GitHub side is covered by `DEFAULT_ISSUE_FIELDS` containing `assignees` (guarded by `test_default_issue_fields_includes_assignees`) plus the existing write-path auto-refresh in `issue/github/provider.py`.
- [x] AC5 (existing snapshot tests for no-assignee payloads): `test_existing_snapshot_payload_still_renders_without_assignee_field` plus all 561 pre-existing tests still pass.
- [x] AC6 (lockstep version bump, both runtimes covered): manifests are at `0.5.1`; scripts are runtime-agnostic Python (no Claude/Codex branching).

Closes #99