### PR TITLE
#141 Wrap hook injection context in <policy>/inner tags; move issue-implementer procedures to agent body

### DIFF
--- a/plugins/workflow/AGENTS.md
+++ b/plugins/workflow/AGENTS.md
@@ -60,7 +60,7 @@ Where the injected text comes from:
     a commit keyword fires)
 - **Agents run as subagents** — `SubagentStart` injects from
   `hooks/context/subagent/`:
-  - `policy.md` (general subagent policy)
+  - `session-start.md` (general subagent policy)
   - `agents/<agent-name>.md` (per-agent block, when present)
 - **Inline snippets** — `hooks/context/snippets/authoring.md` (authoring
   resolver) and `hooks/context/snippets/launcher/<runtime>.md` (launcher
@@ -85,10 +85,13 @@ whenever the layout above looks stale.
 
 Rules that follow:
 
-- Refer to injected blocks by name (e.g., "use the **Publish a review**
-  block from the SubagentStart-injected `issue-implementer subagent
-  context`") instead of restating provider-specific command shapes that
-  the runtime will inject anyway.
+- Refer to injected blocks by tag (e.g., `<launcher>`, `<authoring-resolver>`,
+  `<commit-prefix>`, `<runbook>`) and point at runbook intents by tag
+  (e.g., "verb syntax at `<runbook>`'s `issue-new` intent") instead of
+  restating provider-specific command shapes that the runtime will inject
+  anyway. Procedures that span multiple runbook intents belong in the
+  agent body as a named section the body refers to internally — not in
+  the SubagentStart per-agent block, which only carries injected tags.
 - Do not assume cross-surface context. A skill (main session) sees
   `main/...` blocks; a subagent sees `subagent/...` blocks. Crossing the
   boundary leaves the runtime doc missing assumed context — surface the

--- a/plugins/workflow/agents/issue-implementer.md
+++ b/plugins/workflow/agents/issue-implementer.md
@@ -16,7 +16,7 @@ You are an autonomous implementer for workflow `task`, `bug`, and `spike` issues
 The calling session names:
 
 - **Issue handle**, exactly one of:
-  - `issue-ref` — the provider's native form (e.g., `#127` on GitHub; the equivalent key on Jira). The agent fetches the issue via `workflow issue fetch` (verb syntax in `issue-fetch/<provider>.md` of the runbook).
+  - `issue-ref` — the provider's native form (e.g., `#127` on GitHub; the equivalent key on Jira). The agent fetches the issue via `workflow issue fetch` (verb syntax at `<runbook>`'s `issue-fetch` intent).
   - `issue-cache-path` — an absolute path to an already-cached issue body file the fetch verb emits. The agent reads it directly without re-fetching. Use this when the caller (typically the `implement-issue` skill) already pulled the issue in the same session.
 - Optional **`plan-file`** — an absolute path to a plan file the caller wrote, typically the plan-mode-approved plan handed off by the `implement-issue` skill. Names files to touch by absolute path, the verification step for each Acceptance Criterion, and the intended commit split. When present, treat as authoritative — see Flow step 2.
 - Optional **extra requirements** — emphasis the caller wants woven into the relevant flow step ("focus on X", "skip Y", "use library Z"). Treat these the same way the `implement-issue` skill treats `$ARGUMENTS` past the ref.
@@ -25,12 +25,14 @@ If neither `issue-ref` nor `issue-cache-path` is supplied, stop and ask. Do not 
 
 ## Workflow policy and launcher
 
-The SubagentStart hook injects:
+The SubagentStart hook wraps every injected block in `<policy>...</policy>`; inside it the agent sees these tags:
 
-- The workflow launcher contract — every workflow operation runs through it.
-- The authoring-resolver block — call it to learn which authoring docs to read before drafting any issue body.
-- A reference list pointing at the runbook at `${WORKFLOW_PLUGIN_ROOT}/authoring/runbook/<intent>/<provider>.md`. Read the matching intent file on demand for verb syntax and flag sets (`issue-fetch`, `issue-new`, `issue-link`, `issue-update`, `issue-write`, etc.).
-- An `issue-implementer subagent context` block with flow-specific hints for **Publish a review**, **Link the implementation task as blocked by the review**, and **Refresh the implementation task's body**. The agent body does not restate these — refer to them by name from the injected block. The active provider's command syntax lives in the runbook; read it when invoking these verbs.
+- `<launcher>` — the workflow launcher contract. Every workflow operation runs through it.
+- `<authoring-resolver>` — call the resolver invocation inside to learn which authoring docs to read before drafting any issue body.
+- `<commit-prefix>` — commit-prefix policy specific to this agent. Every commit subject follows it.
+- `<runbook>` — reference docs (read on demand) at `${WORKFLOW_PLUGIN_ROOT}/authoring/runbook/<intent>/<provider>.md`. The tag lists the intents this agent uses (`issue-fetch`, `issue-write`, `issue-new`, `issue-link`, `issue-update`, `issue-state`). Read the matching intent file on demand for verb syntax and flag sets.
+
+The agent body owns the procedures for **Publish a review**, **Link the implementation task as blocked by the review**, and **Refresh the implementation task's body** — see `## Publish / link / writeback procedures` below. The active provider's command syntax lives in the runbook; read it when invoking these verbs.
 
 When the flow calls `workflow authoring_resolver.py --type review --raw`, follow the docs that the resolver names in its output.
 
@@ -42,7 +44,7 @@ For any other type (`epic`, `review`, `research`, `usecase`, knowledge types), s
 
 ## Flow
 
-1. **Resolve the issue handle.** If `issue-cache-path` was supplied, read that file directly. Otherwise fetch `issue-ref` via `workflow issue fetch` (verb syntax in `issue-fetch/<provider>.md` of the runbook) and read the cached body file the fetch verb returns. Follow the links the body cites: `Parent`, `Blocked-by`, knowledge pages, and paths named in `Affected Paths`. The body's spec sections define the outcome to achieve; the body's planned approach is what you build the execution plan on. Its links complete both.
+1. **Resolve the issue handle.** If `issue-cache-path` was supplied, read that file directly. Otherwise fetch `issue-ref` via `workflow issue fetch` (verb syntax at `<runbook>`'s `issue-fetch` intent) and read the cached body file the fetch verb returns. Follow the links the body cites: `Parent`, `Blocked-by`, knowledge pages, and paths named in `Affected Paths`. The body's spec sections define the outcome to achieve; the body's planned approach is what you build the execution plan on. Its links complete both.
 
 2. **Adopt or derive the plan, then cross-check it against the current code.** If `plan-file` was supplied, read it and treat it as authoritative: verify it covers every Acceptance Criterion and aligns with the body's planned approach. If a supplied plan demonstrably contradicts the body (missing AC coverage, wrong files), jump to **Blocker handling** and publish a review — do not silently rewrite the approved plan. If no plan was supplied, derive one internally from the body. Either way you do **not** present the plan for approval. If the body is ambiguous enough that no concrete plan can be formed and the caller supplied none, jump to **Blocker handling** and publish a review.
 
@@ -73,11 +75,27 @@ For any other type (`epic`, `review`, `research`, `usecase`, knowledge types), s
 
    For `bug`, the regression test plus fix evidence determines whether all AC are met. For `spike`, captured evidence (Artifact Links plus short summary) accompanies the body update on whichever branch is chosen.
 
-10. **Refresh `Resume` and execute the writeback.** Use the **Refresh the implementation task's body** block from the SubagentStart-injected `issue-implementer subagent context`.
+10. **Refresh `Resume` and execute the writeback.** Apply the **Refresh the implementation task's body** procedure (see `## Publish / link / writeback procedures` below).
 
-    - **`still open: handoff (PR: <ref>)`**: handoff snapshot — `Approach` summarises what landed in the PR, `Waiting for` names the PR ref, `Open questions` enumerates any deferred AC each labelled as a follow-up candidate or follow-up ref, `Next` is "merge <PR-ref>". Body-only writeback (the body-only form of the injected block); the agent does **not** resolve the issue itself.
-    - **`resolved: <provider terminal reason>`**: terminal snapshot — `Approach` summarised, `Waiting for` empty, `Open questions` resolved. Use the body + state form of the injected writeback block to update body and apply the provider's terminal transition in one call.
+    - **`still open: handoff (PR: <ref>)`**: handoff snapshot — `Approach` summarises what landed in the PR, `Waiting for` names the PR ref, `Open questions` enumerates any deferred AC each labelled as a follow-up candidate or follow-up ref, `Next` is "merge <PR-ref>". Body-only writeback (the body-only form of the procedure); the agent does **not** resolve the issue itself.
+    - **`resolved: <provider terminal reason>`**: terminal snapshot — `Approach` summarised, `Waiting for` empty, `Open questions` resolved. Use the body + state form of the procedure to update body and apply the provider's terminal transition in one call.
     - **`still open: <other reason>`**: progress snapshot reflecting current state (what landed so far, what blocks the next move, unresolved questions, the next action). Body-only writeback; no state transition.
+
+## Publish / link / writeback procedures
+
+These procedures cover the three workflow verb invocations the agent reaches for outside the implementation loop itself: publishing a `review` issue when a blocker fires, linking the implementation task as `blocked-by` that review, and refreshing the implementation task's body at handoff / paused / closed time. Each procedure points at the matching `<runbook>` intent for verb syntax, flag sets, body-file lifecycle, and freshness-drift handling — read the runbook file on demand rather than restating its contents here.
+
+### Publish a review
+
+Used by the blocker-handling flow. Publish a `review` issue via `workflow issue new --type review` with a body file drafted at the resolver-returned path. Capture the returned review ref from the script's JSON output for use in the link and writeback procedures below. Verb syntax at `<runbook>`'s `issue-new` intent.
+
+### Link the implementation task as blocked by the review
+
+Used immediately after **Publish a review**. Mark the implementation task as `--blocked-by` the newly published review via `workflow issue link`. Verb syntax at `<runbook>`'s `issue-link` intent.
+
+### Refresh the implementation task's body
+
+Used at handoff (success), at pause / blocker, and at terminal close. Refresh the implementation task's body via `workflow issue update` with a temp body file (handoff / paused `Resume` snapshot or closed snapshot). To close the issue in the same call, combine `--state` — provider state syntax at `<runbook>`'s `issue-state` intent. Verb syntax at `<runbook>`'s `issue-update` intent.
 
 ## Blocker handling — publish a review issue
 
@@ -104,9 +122,9 @@ Any of these triggers the review publish flow before any commit:
 Per review authoring rules, **one review = one concern**. If multiple independent concerns surfaced, the review covers the primary blocker only; surface the others in the final report as candidates for separate review. Name the implementation issue ref as the review's target so the relationship is reviewable from either side.
 
 1. Resolve authoring with `workflow authoring_resolver.py --type review --raw` and follow the docs / draft path the resolver returns. The authoring docs define what the review body must contain; do not restate them here.
-2. Publish the review per the **Publish a review** block from the SubagentStart-injected `issue-implementer subagent context` (verb syntax in `issue-new/<provider>.md` of the runbook). Capture the returned review ref.
-3. Link the implementation task as blocked by the review per the **Link the implementation task as blocked by the review** block (verb syntax in `issue-link/<provider>.md` of the runbook).
-4. Refresh `Resume` on the implementation task per the **Refresh the implementation task's body** block (body-only form; verb syntax in `issue-update/<provider>.md` of the runbook) — `Approach` summarises what landed locally up to the blocker, `Waiting for` names the review ref, `Open questions` enumerates the concern the review captures, `Next` is "resolve <review-ref>". Do **not** apply any terminal state transition to the implementation task.
+2. Publish the review per the **Publish a review** procedure (verb syntax at `<runbook>`'s `issue-new` intent). Capture the returned review ref.
+3. Link the implementation task as blocked by the review per the **Link the implementation task as blocked by the review** procedure (verb syntax at `<runbook>`'s `issue-link` intent).
+4. Refresh `Resume` on the implementation task per the **Refresh the implementation task's body** procedure (body-only form; verb syntax at `<runbook>`'s `issue-update` intent) — `Approach` summarises what landed locally up to the blocker, `Waiting for` names the review ref, `Open questions` enumerates the concern the review captures, `Next` is "resolve <review-ref>". Do **not** apply any terminal state transition to the implementation task.
 5. The harness keeps the isolated worktree on disk automatically when any uncommitted edits, untracked files, or commits exist — so local exploration done before the blocker fired stays available for the user to take over after the review resolves. The agent takes no explicit cleanup action.
 
 ## What you do NOT do

--- a/plugins/workflow/hooks/context/main/session-start.md
+++ b/plugins/workflow/hooks/context/main/session-start.md
@@ -1,10 +1,18 @@
-## workflow policy
+<launcher>
 
 {{SNIPPET_LAUNCHER}}
+
+</launcher>
+
+<authoring-resolver>
 
 Resolve authoring paths before any issue or knowledge pages:
 
 {{SNIPPET_AUTHORING}}
+
+</authoring-resolver>
+
+<runbook>
 
 Reference docs (read on demand) at
 `{{WORKFLOW_RUNBOOK_DIR}}/<intent>/{{WORKFLOW_ISSUE_PROVIDER}}.md`:
@@ -16,6 +24,8 @@ Reference docs (read on demand) at
 - `issue-update` — update body, title, labels, or state
 - `issue-link` — relationships
 - `issue-state` — body-less verbs (state, assign, unassign, set-type)
+
+</runbook>
 
 Don't quote, paraphrase, or summarize issue bodies, comments, or knowledge
 documents beyond what the user asked for. The cached `issue.md` and

--- a/plugins/workflow/hooks/context/snippets/authoring.md
+++ b/plugins/workflow/hooks/context/snippets/authoring.md
@@ -1,9 +1,9 @@
-```bash
+<bash>
 workflow authoring_resolver.py \
   --type <type> \
   [--role issue|knowledge] \
   [--scope comment]
-```
+</bash>
 
 - `--type` — required.
 - `--role` — required for dual-role types (`issue` or `knowledge`); omit

--- a/plugins/workflow/hooks/context/snippets/commit-prefix.md
+++ b/plugins/workflow/hooks/context/snippets/commit-prefix.md
@@ -1,1 +1,1 @@
-## Prefix commit subjects with the related issue ref; ask the user if it is unclear.
+Prefix commit subjects with the related issue ref; ask the user if it is unclear.

--- a/plugins/workflow/hooks/context/subagent/agents/issue-implementer.md
+++ b/plugins/workflow/hooks/context/subagent/agents/issue-implementer.md
@@ -1,11 +1,16 @@
-## issue-implementer subagent context
+<commit-prefix>
 
 {{SNIPPET_COMMIT_PREFIX}}
+
+</commit-prefix>
+
+<runbook>
 
 Per-verb syntax (flags, body-file lifecycle, freshness-drift handling)
 lives in the runbook at
 `{{WORKFLOW_RUNBOOK_DIR}}/<intent>/{{WORKFLOW_ISSUE_PROVIDER}}.md`:
 
+- `issue-fetch` — fetch issues + cache projections
 - `issue-write` — shared body-bearing write procedure
 - `issue-new` — publish a new issue (used for the review publish flow)
 - `issue-link` — relationships (used for the blocked-by link)
@@ -13,22 +18,4 @@ lives in the runbook at
 - `issue-state` — provider terminal-transition verbs (when combining
   `--state` on update)
 
-### Publish a review (blocker handling)
-
-Blocker-handling flow: publish a `review` issue via `workflow issue new
---type review` with a body file drafted at the resolver-returned path.
-Capture the returned review ref from the script's JSON output.
-
-### Link the implementation task as blocked by the review
-
-Writeback link: mark the implementation task as `--blocked-by` the
-newly published review via `workflow issue link`.
-
-### Refresh the implementation task's body (handoff Resume / closed snapshot)
-
-Writeback flow: refresh the implementation task's body via `workflow
-issue update` with a temp body file (handoff / paused `Resume`
-snapshot or closed snapshot). Combine `--state` on the same call to
-close — see `issue-update/{{WORKFLOW_ISSUE_PROVIDER}}.md` and
-`issue-state/{{WORKFLOW_ISSUE_PROVIDER}}.md` for the provider's state
-syntax.
+</runbook>

--- a/plugins/workflow/hooks/context/subagent/session-start.md
+++ b/plugins/workflow/hooks/context/subagent/session-start.md
@@ -1,17 +1,24 @@
-## workflow subagent context
+<launcher>
 
 This subagent runs inside a workflow-configured project. The main session's
 workflow launcher contract is inherited in your shell:
 
 {{SNIPPET_LAUNCHER}}
 
+</launcher>
+
+<authoring-resolver>
+
 Resolve authoring paths before any issue or knowledge pages:
 
 {{SNIPPET_AUTHORING}}
+
+</authoring-resolver>
+
+<runbook>
 
 Reference doc (read on demand) at
 `{{WORKFLOW_RUNBOOK_DIR}}/issue-fetch/{{WORKFLOW_ISSUE_PROVIDER}}.md`
 — fetch issues + cache projections.
 
-Write-side runbook intents are not enumerated here; agents that need
-them receive a per-agent block naming the runbook paths they use.
+</runbook>

--- a/plugins/workflow/scripts/authoring_resolver.py
+++ b/plugins/workflow/scripts/authoring_resolver.py
@@ -112,12 +112,12 @@ def _anchor_scope_suffix(scope: str) -> str:
     return "-comment" if scope == "comment" else ""
 
 
-def reading_list_anchor(artifact_type: str, role: str, scope: str) -> str:
-    return f"{artifact_type}-{role}{_anchor_scope_suffix(scope)}-reading-list"
+def reading_anchor(artifact_type: str, role: str, scope: str) -> str:
+    return f"{artifact_type}-{role}{_anchor_scope_suffix(scope)}"
 
 
 def notes_anchor(artifact_type: str, role: str, scope: str) -> str:
-    return f"{artifact_type}-{role}{_anchor_scope_suffix(scope)}-notes"
+    return f"{artifact_type}-{role}{_anchor_scope_suffix(scope)}"
 
 
 @dataclass(frozen=True)
@@ -132,8 +132,8 @@ class Resolution:
     notes: tuple[str, ...] = ()
 
     @property
-    def reading_list_anchor(self) -> str:
-        return reading_list_anchor(self.artifact_type, self.role, self.scope)
+    def reading_anchor(self) -> str:
+        return reading_anchor(self.artifact_type, self.role, self.scope)
 
     @property
     def notes_anchor(self) -> str:
@@ -141,27 +141,30 @@ class Resolution:
 
     def to_markdown(self) -> str:
         sections: list[str] = []
-        reading_lines = [f"## {self.reading_list_anchor}"]
+        reading_lines = [f'<reading anchor="{self.reading_anchor}">']
         reading_lines.append(f"Base: {AUTHORING_DIR}")
         reading_lines.extend(
             f"- {path.relative_to(AUTHORING_DIR)}" for path in self.files
         )
+        reading_lines.append("</reading>")
         sections.append("\n".join(reading_lines))
         if self.notes:
-            notes_lines = [f"## {self.notes_anchor}"]
+            notes_lines = [f'<notes anchor="{self.notes_anchor}">']
             notes_lines.extend(f"- {note}" for note in self.notes)
+            notes_lines.append("</notes>")
             sections.append("\n".join(notes_lines))
         return "\n\n".join(sections) + "\n"
 
 
 def render_cache_hit_reference(
-    reading_list_anchor: str,
+    reading_anchor: str,
     notes_anchor: str | None = None,
 ) -> str:
-    lines = [f"- See `{reading_list_anchor}` above."]
+    lines = [f'- See `<reading anchor="{reading_anchor}">` above.']
     if notes_anchor is not None:
         lines.append(
-            f"- See `{notes_anchor}` above — triggers apply to this call too."
+            f'- See `<notes anchor="{notes_anchor}">` above — '
+            "triggers apply to this call too."
         )
     lines.append(
         "- If the anchor body is no longer in context, rerun this command "
@@ -395,7 +398,7 @@ def main(argv: list[str] | None = None) -> int:
         print(resolution.to_markdown(), end="")
         return 0
 
-    anchor = resolution.reading_list_anchor
+    anchor = resolution.reading_anchor
     current_key = _resolution_key(resolution)
     use_cache_hit = False
     if not args.raw:
@@ -411,7 +414,8 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(
             render_cache_hit_reference(
-                resolution.reading_list_anchor, notes_anchor_value
+                resolution.reading_anchor,
+                notes_anchor_value,
             ),
             end="",
         )

--- a/plugins/workflow/scripts/authoring_resolver.py
+++ b/plugins/workflow/scripts/authoring_resolver.py
@@ -403,7 +403,7 @@ def main(argv: list[str] | None = None) -> int:
     use_cache_hit = False
     if not args.raw:
         existing = read_authoring_resolution(
-            args.project, runtime, session_id, anchor
+            args.project, runtime, session_id, tag="reading", anchor=anchor
         )
         if existing is not None and _keys_equal(existing.get("key"), current_key):
             use_cache_hit = True
@@ -421,17 +421,24 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
-    rendered = resolution.to_markdown()
-    print(rendered, end="")
-    body_lines = rendered.rstrip("\n").splitlines() if rendered else []
+    print(resolution.to_markdown(), end="")
     record_authoring_resolution(
         args.project,
         runtime,
         session_id,
+        tag="reading",
         anchor=anchor,
         key=current_key,
-        body=body_lines,
     )
+    if resolution.notes:
+        record_authoring_resolution(
+            args.project,
+            runtime,
+            session_id,
+            tag="notes",
+            anchor=resolution.notes_anchor,
+            key=current_key,
+        )
     return 0
 
 

--- a/plugins/workflow/scripts/workflow_main_context.py
+++ b/plugins/workflow/scripts/workflow_main_context.py
@@ -76,16 +76,17 @@ def build_session_policy_context(
 
     text = _read_fragment("main/session-start.md").strip()
     if plugin_root is None:
-        return text
+        return _wrap_policy(text)
     resolved_plugin_root = plugin_root.expanduser().resolve()
     runbook_dir = resolved_plugin_root / "authoring" / "runbook"
     issue_provider = _provider_segment(config, "issues", _KNOWN_ISSUE_PROVIDERS)
-    return render(text, {
+    rendered = render(text, {
         "SNIPPET_LAUNCHER": _build_launcher_block(runtime, resolved_plugin_root),
         "SNIPPET_AUTHORING": _read_fragment("snippets/authoring.md").strip(),
         "WORKFLOW_RUNBOOK_DIR": str(runbook_dir),
         "WORKFLOW_ISSUE_PROVIDER": issue_provider,
     })
+    return _wrap_policy(rendered)
 
 
 def build_subagent_policy_context(
@@ -99,7 +100,7 @@ def build_subagent_policy_context(
 
     text = _read_fragment("subagent/session-start.md").strip()
     if plugin_root is None:
-        return text
+        return _wrap_policy(text)
     resolved_plugin_root = plugin_root.expanduser().resolve()
     runbook_dir = resolved_plugin_root / "authoring" / "runbook"
     issue_provider = _provider_segment(config, "issues", _KNOWN_ISSUE_PROVIDERS)
@@ -110,9 +111,48 @@ def build_subagent_policy_context(
         "WORKFLOW_ISSUE_PROVIDER": issue_provider,
     })
     agent_block = _build_agent_context_block(agent_type, issue_provider, runbook_dir)
-    if agent_block:
-        rendered = f"{rendered}\n\n{agent_block}"
-    return rendered
+    merged = _merge_runbook_blocks(rendered, agent_block)
+    return _wrap_policy(merged)
+
+
+_RUNBOOK_BLOCK_RE = re.compile(
+    r"\n?<runbook>\s*\n?(?P<body>.*?)\n?\s*</runbook>\n?",
+    re.DOTALL,
+)
+
+
+def _merge_runbook_blocks(base: str, per_agent: str) -> str:
+    """Combine a base subagent context with an optional per-agent block.
+
+    If ``per_agent`` carries its own ``<runbook>...</runbook>`` block, the
+    base's ``<runbook>`` is stripped first so the merged text emits a
+    single ``<runbook>``. Any empty ``<runbook>`` (whitespace-only body)
+    is removed from the combined text — agents without listed intents
+    do not get an empty tag injected.
+    """
+
+    def has_runbook(text: str) -> bool:
+        return _RUNBOOK_BLOCK_RE.search(text) is not None
+
+    def strip_empty_runbooks(text: str) -> str:
+        def replace(match: re.Match[str]) -> str:
+            body = match.group("body").strip()
+            return "" if not body else match.group(0)
+
+        return _RUNBOOK_BLOCK_RE.sub(replace, text)
+
+    if per_agent and has_runbook(per_agent):
+        base = _RUNBOOK_BLOCK_RE.sub("\n\n", base, count=1)
+        base = base.rstrip()
+    combined = f"{base}\n\n{per_agent}" if per_agent else base
+    combined = strip_empty_runbooks(combined)
+    # Collapse 3+ consecutive newlines that the strip-and-merge can leave behind.
+    combined = re.sub(r"\n{3,}", "\n\n", combined)
+    return combined.strip()
+
+
+def _wrap_policy(text: str) -> str:
+    return f"<policy>\n{text.strip()}\n</policy>"
 
 
 def _build_agent_context_block(

--- a/plugins/workflow/scripts/workflow_session_state.py
+++ b/plugins/workflow/scripts/workflow_session_state.py
@@ -296,13 +296,17 @@ def read_authoring_resolution(
     project: Path,
     runtime: str,
     session_id: str,
+    *,
+    tag: str,
     anchor: str,
 ) -> dict[str, Any] | None:
+    normalized_tag = str(tag).strip()
     normalized_anchor = str(anchor).strip()
-    if not normalized_anchor:
+    if not normalized_tag or not normalized_anchor:
         return None
     return _authoring_resolution(
         _read_session_state(project, runtime, session_id),
+        normalized_tag,
         normalized_anchor,
     )
 
@@ -312,20 +316,20 @@ def record_authoring_resolution(
     runtime: str,
     session_id: str,
     *,
+    tag: str,
     anchor: str,
     key: Mapping[str, Any],
-    body: list[str] | tuple[str, ...],
     emitted_at: str | None = None,
 ) -> bool:
+    normalized_tag = str(tag).strip()
     normalized_anchor = str(anchor).strip()
-    if not normalized_anchor:
+    if not normalized_tag or not normalized_anchor:
         return False
     normalized_key = {
         str(name): _coerce_resolution_key_value(value)
         for name, value in dict(key).items()
         if str(name)
     }
-    normalized_body = [str(line) for line in body]
     if emitted_at and str(emitted_at).strip():
         normalized_emitted_at = str(emitted_at).strip()
     else:
@@ -337,9 +341,12 @@ def record_authoring_resolution(
         if not isinstance(resolutions, dict):
             resolutions = {}
             authoring["resolutions"] = resolutions
-        resolutions[normalized_anchor] = {
+        tag_bucket = resolutions.get(normalized_tag)
+        if not isinstance(tag_bucket, dict):
+            tag_bucket = {}
+            resolutions[normalized_tag] = tag_bucket
+        tag_bucket[normalized_anchor] = {
             "key": dict(normalized_key),
-            "body": list(normalized_body),
             "emitted_at": normalized_emitted_at,
         }
 
@@ -576,7 +583,7 @@ def _authoring_file_reads(state: Mapping[str, Any]) -> list[dict[str, str]]:
 
 
 def _authoring_resolution(
-    state: Mapping[str, Any], anchor: str
+    state: Mapping[str, Any], tag: str, anchor: str
 ) -> dict[str, Any] | None:
     authoring = state.get("authoring")
     if not isinstance(authoring, Mapping):
@@ -584,24 +591,24 @@ def _authoring_resolution(
     resolutions = authoring.get("resolutions")
     if not isinstance(resolutions, Mapping):
         return None
-    entry = resolutions.get(anchor)
+    tag_bucket = resolutions.get(tag)
+    if not isinstance(tag_bucket, Mapping):
+        return None
+    entry = tag_bucket.get(anchor)
     if not isinstance(entry, Mapping):
         return None
     raw_key = entry.get("key")
-    raw_body = entry.get("body")
     raw_emitted_at = entry.get("emitted_at")
-    if not isinstance(raw_key, Mapping) or not isinstance(raw_body, list):
+    if not isinstance(raw_key, Mapping):
         return None
     coerced_key: dict[str, str | None] = {}
     for name, value in raw_key.items():
         if not isinstance(name, str) or not name:
             continue
         coerced_key[name] = None if value is None else str(value)
-    coerced_body = [str(line) for line in raw_body if isinstance(line, str)]
     coerced_emitted_at = raw_emitted_at if isinstance(raw_emitted_at, str) else ""
     return {
         "key": coerced_key,
-        "body": coerced_body,
         "emitted_at": coerced_emitted_at,
     }
 

--- a/plugins/workflow/scripts/workflow_setup.py
+++ b/plugins/workflow/scripts/workflow_setup.py
@@ -38,6 +38,7 @@ from workflow_config import (  # noqa: E402
     KNOWLEDGE_PROVIDERS,
     PROVIDER_NATIVE_ISSUE_ID_FORMATS,
     ProviderConfig,
+    WorkflowConfig,
     WorkflowConfigError,
     load_workflow_config,
     parse_workflow_config,
@@ -464,6 +465,74 @@ def build_config_payload(raw: Mapping[str, Any], *, project: Path) -> dict[str, 
     }
 
 
+AGENTS_FILENAME = "AGENTS.md"
+CLAUDE_FILENAME = "CLAUDE.md"
+AGENTS_KNOWLEDGE_HEADING = "## Workflow Knowledge Root"
+CLAUDE_AGENTS_SHIM = "@AGENTS.md\n"
+
+
+def _knowledge_root_section(repo_relative: str, absolute: str) -> str:
+    return (
+        f"{AGENTS_KNOWLEDGE_HEADING}\n\n"
+        f"Workflow knowledge pages live at `{repo_relative}` "
+        f"(resolved: `{absolute}`).\n"
+    )
+
+
+def ensure_agents_knowledge_root(
+    project: Path, config: WorkflowConfig
+) -> dict[str, Any] | None:
+    """Append the workflow knowledge-root section to ``AGENTS.md`` when applicable.
+
+    The section is appended only when it is not already present. ``CLAUDE.md`` is
+    auto-created as a sibling shim (``@AGENTS.md``) when missing, matching the
+    project convention. Returns ``None`` when there is no configured knowledge
+    path to surface.
+    """
+
+    if config.knowledge.kind != "github":
+        return None
+    raw_path = config.knowledge.settings.get("path")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+
+    project = project.expanduser().resolve()
+    repo_relative = raw_path.strip()
+    absolute = str((project / repo_relative).resolve())
+    section = _knowledge_root_section(repo_relative, absolute)
+
+    agents_path = project / AGENTS_FILENAME
+    if agents_path.exists():
+        existing = agents_path.read_text(encoding="utf-8")
+        if AGENTS_KNOWLEDGE_HEADING in existing:
+            agents_action = "skip"
+        else:
+            separator = "" if existing.endswith("\n") else "\n"
+            _atomic_write_text(agents_path, existing + separator + "\n" + section)
+            agents_action = "append"
+    else:
+        _atomic_write_text(agents_path, section)
+        agents_action = "create"
+
+    claude_path = project / CLAUDE_FILENAME
+    if claude_path.exists():
+        claude_action = "skip"
+    else:
+        _atomic_write_text(claude_path, CLAUDE_AGENTS_SHIM)
+        claude_action = "create"
+
+    return {
+        "agents_path": str(agents_path),
+        "agents_action": agents_action,
+        "claude_path": str(claude_path),
+        "claude_action": claude_action,
+        "knowledge_root": {
+            "repo_relative": repo_relative,
+            "absolute": absolute,
+        },
+    }
+
+
 def write_config(
     project: Path,
     raw: Mapping[str, Any],
@@ -492,7 +561,7 @@ def write_config(
     if verified is None:
         raise WorkflowSetupError(f"{CONFIG_NAME} was written but could not be verified")
 
-    return {
+    result: dict[str, Any] = {
         "operation": "write",
         "path": str(target),
         "verified": True,
@@ -501,6 +570,10 @@ def write_config(
             "config": verified.to_json(),
         },
     }
+    agents_update = ensure_agents_knowledge_root(project, verified)
+    if agents_update is not None:
+        result["agents_md"] = agents_update
+    return result
 
 
 def existing_config_summary(project: Path) -> dict[str, Any]:
@@ -747,7 +820,7 @@ def _add_config_build_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--github-issue-host", help="GitHub issue provider host when it differs from the wiki host")
     parser.add_argument("--github-wiki-repo", help="GitHub knowledge repository slug when different from issue repo")
     parser.add_argument("--github-wiki-host", help="GitHub knowledge/wiki repository host when it differs from the issue host")
-    parser.add_argument("--github-wiki-path", default="wiki/workflow", help="GitHub repository wiki directory path")
+    parser.add_argument("--github-wiki-path", help="GitHub knowledge repository directory path (required for the github knowledge provider; no default is assumed)")
     parser.add_argument("--jira-site", help="Jira Data Center or Server base URL")
     parser.add_argument("--jira-deployment", default="data_center", help="Jira deployment; Cloud is unsupported")
     parser.add_argument("--jira-api-version", default="2", help="Jira REST API version")
@@ -906,7 +979,7 @@ def _knowledge_provider_config(
     if provider == "github":
         _set_if_text(settings, "repo", github_repo)
         _set_if_text(settings, "host", github_host)
-        _set_if_text(settings, "path", github_path or "wiki/workflow")
+        _set_if_text(settings, "path", github_path)
     return settings
 
 

--- a/plugins/workflow/skills/setup/SKILL.md
+++ b/plugins/workflow/skills/setup/SKILL.md
@@ -47,7 +47,14 @@ workflow workflow_config.py --project <project-root> --require
    when it was not already named explicitly by the user or a provider profile;
    do not infer it from a Git remote or assume GitHub.
 4. Collect the knowledge provider: `github`. Ask the user when it was
-   not already named explicitly by the user or a provider profile.
+   not already named explicitly by the user or a provider profile. For
+   the `github` knowledge provider, also collect the knowledge folder
+   path (`--github-wiki-path`) from the user. There is no default; ask
+   the user which repo-relative folder should hold knowledge pages (for
+   example `wiki/<project>`, `docs/workflow`, or `knowledge/`) and pass
+   the confirmed value through `--github-wiki-path`. Do not assume,
+   suggest, or fall back to `wiki/workflow` or any other path the user
+   has not named.
 5. If the issue provider is `jira`, run the Jira site profiling flow before
    `capabilities` or `build-config`. Collect representative sample issue keys,
    inspect relationship surfaces, ask the user to confirm exact mappings, and
@@ -74,6 +81,16 @@ workflow workflow_config.py --project <project-root> --require
    explicit confirmation before writing.
 11. After confirmation, write with `write --config <reviewed-yaml-file>`. Then
    verify with `workflow_config.py --require`.
+12. `write` also records the configured knowledge folder under a
+   `## Workflow Knowledge Root` section in `<project-root>/AGENTS.md`
+   (auto-created when missing) and creates `<project-root>/CLAUDE.md`
+   as a `@AGENTS.md` shim if absent. The section is appended only when
+   the heading is not already present; an existing section is left
+   untouched so the agent should manually update the heading body when
+   the configured knowledge path changes. Skipped when the github
+   knowledge provider has no `path` configured. Inspect `result.agents_md`
+   from the `write` payload to see which actions ran
+   (`create` / `append` / `skip`).
 
 ## Provider Rules
 
@@ -85,10 +102,14 @@ workflow workflow_config.py --project <project-root> --require
 - Always pass explicit `--issue-provider` and `--knowledge-provider` values to
   `build-config` or `write` when building config from options. Missing provider
   flags mean setup is incomplete; ask for the provider choice before continuing.
-- GitHub knowledge setup represents a repository `wiki/<plugin>/` directory.
-  Use `--github-wiki-path`, defaulting to `wiki/workflow` when the user accepts
-  that path. If the knowledge/wiki repository host differs from the issue
-  repository host, use `--github-wiki-host`.
+- GitHub knowledge setup represents a repository-relative directory.
+  `--github-wiki-path` has no default and must be supplied by the user.
+  Always ask the user which folder should hold the knowledge pages
+  (for example `wiki/<project>`, `docs/workflow`, `knowledge/`) and pass
+  the confirmed value exactly through `--github-wiki-path`. Do not
+  assume, suggest, or fall back to `wiki/workflow` or any other path
+  the user has not named. If the knowledge/wiki repository host differs
+  from the issue repository host, use `--github-wiki-host`.
 - Jira setup targets Data Center or Server only. Reject or report Cloud,
   including `*.atlassian.net` sites.
 - Jira issue setup requires explicit `providers.issues.relationship_mappings`

--- a/plugins/workflow/tests/fixtures/setup/filesystem-github.yml
+++ b/plugins/workflow/tests/fixtures/setup/filesystem-github.yml
@@ -6,7 +6,6 @@ providers:
     path: workflow/issues
   knowledge:
     kind: github
-    path: wiki/workflow
 issue_id_format: number
 commit_refs:
   enabled: false

--- a/plugins/workflow/tests/test_authoring_resolver.py
+++ b/plugins/workflow/tests/test_authoring_resolver.py
@@ -466,19 +466,23 @@ def test_main_first_call_emits_sections_and_persists(
     assert '<reading anchor="task-issue">' in out
     assert '<notes anchor="task-issue">' in out
 
-    entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue"
+    reading_entry = read_authoring_resolution(
+        tmp_path, runtime, session_id, tag="reading", anchor="task-issue"
     )
-    assert entry is not None
-    assert entry["key"] == {
+    assert reading_entry is not None
+    assert reading_entry["key"] == {
         "type": "task",
         "role": "issue",
         "provider": "github",
         "scope": "content",
     }
-    assert entry["body"]
-    assert entry["body"][0] == '<reading anchor="task-issue">'
-    assert entry["emitted_at"]
+    assert reading_entry["emitted_at"]
+
+    notes_entry = read_authoring_resolution(
+        tmp_path, runtime, session_id, tag="notes", anchor="task-issue"
+    )
+    assert notes_entry is not None
+    assert notes_entry["key"] == reading_entry["key"]
 
 
 def test_main_repeat_call_emits_bullet_only_form(
@@ -533,7 +537,7 @@ def test_main_raw_flag_forces_section_emission(
     authoring_resolver_main(base)
     capsys.readouterr()
     first_entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue"
+        tmp_path, runtime, session_id, tag="reading", anchor="task-issue"
     )
 
     authoring_resolver_main(base + ["--raw"])
@@ -541,7 +545,7 @@ def test_main_raw_flag_forces_section_emission(
 
     assert '<reading anchor="task-issue">' in out
     second_entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue"
+        tmp_path, runtime, session_id, tag="reading", anchor="task-issue"
     )
     assert first_entry is not None
     assert second_entry is not None
@@ -564,7 +568,7 @@ def test_main_provider_drift_triggers_refresh(
 
     assert '<reading anchor="task-issue">' in out
     entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue"
+        tmp_path, runtime, session_id, tag="reading", anchor="task-issue"
     )
     assert entry is not None
     assert entry["key"]["provider"] == "jira"

--- a/plugins/workflow/tests/test_authoring_resolver.py
+++ b/plugins/workflow/tests/test_authoring_resolver.py
@@ -20,7 +20,7 @@ from authoring_resolver import (  # noqa: E402
     is_authoring_file,
     main as authoring_resolver_main,
     notes_anchor,
-    reading_list_anchor,
+    reading_anchor,
     render_cache_hit_reference,
     resolve_authoring,
 )
@@ -288,20 +288,20 @@ def test_task_comment_scope_omits_notes() -> None:
 @pytest.mark.parametrize(
     "artifact_type,role,scope,expected_reading,expected_notes",
     [
-        ("task", "issue", "content", "task-issue-reading-list", "task-issue-notes"),
-        ("bug", "issue", "content", "bug-issue-reading-list", "bug-issue-notes"),
-        ("spike", "issue", "content", "spike-issue-reading-list", None),
-        ("spec", "knowledge", "content", "spec-knowledge-reading-list", None),
+        ("task", "issue", "content", "task-issue", "task-issue"),
+        ("bug", "issue", "content", "bug-issue", "bug-issue"),
+        ("spike", "issue", "content", "spike-issue", None),
+        ("spec", "knowledge", "content", "spec-knowledge", None),
         (
             "task",
             "issue",
             "comment",
-            "task-issue-comment-reading-list",
+            "task-issue-comment",
             None,
         ),
     ],
 )
-def test_to_markdown_emits_expected_anchor_headings(
+def test_to_markdown_emits_expected_anchor_tags(
     artifact_type: str,
     role: str,
     scope: str,
@@ -313,18 +313,20 @@ def test_to_markdown_emits_expected_anchor_headings(
     )
     rendered = resolution.to_markdown()
 
-    assert f"## {expected_reading}\n" in rendered
+    assert f'<reading anchor="{expected_reading}">' in rendered
+    assert "</reading>" in rendered
     if expected_notes is None:
-        assert "-notes" not in rendered
+        assert "<notes " not in rendered
     else:
-        assert f"## {expected_notes}\n" in rendered
+        assert f'<notes anchor="{expected_notes}">' in rendered
+        assert "</notes>" in rendered
 
 
 def test_to_markdown_lists_files_relative_to_a_declared_base() -> None:
     resolution = resolve_authoring("task", role="issue", provider="github")
     rendered = resolution.to_markdown()
 
-    reading_section, _, _ = rendered.partition("\n\n## ")
+    reading_section, _, _ = rendered.partition("</reading>")
     lines = reading_section.splitlines()
     base_lines = [line for line in lines if line.startswith("Base: ")]
     bullet_lines = [line for line in lines if line.startswith("- ")]
@@ -359,41 +361,40 @@ def test_to_markdown_omits_notes_section_for_noteless_types(
     rendered = resolution.to_markdown()
 
     assert resolution.notes == ()
-    assert "-notes" not in rendered
+    assert "<notes " not in rendered
 
 
 @pytest.mark.parametrize(
-    "scope,expected_reading,expected_notes",
+    "scope,expected",
     [
-        ("content", "task-issue-reading-list", "task-issue-notes"),
-        ("comment", "task-issue-comment-reading-list", "task-issue-comment-notes"),
+        ("content", "task-issue"),
+        ("comment", "task-issue-comment"),
     ],
 )
 def test_anchor_helpers_apply_comment_suffix_for_comment_scope(
-    scope: str, expected_reading: str, expected_notes: str
+    scope: str, expected: str
 ) -> None:
-    assert reading_list_anchor("task", "issue", scope) == expected_reading
-    assert notes_anchor("task", "issue", scope) == expected_notes
+    assert reading_anchor("task", "issue", scope) == expected
+    assert notes_anchor("task", "issue", scope) == expected
 
 
 def test_render_cache_hit_reference_with_notes_anchor() -> None:
-    rendered = render_cache_hit_reference(
-        "task-issue-reading-list", "task-issue-notes"
-    )
+    rendered = render_cache_hit_reference("task-issue", "task-issue")
 
     assert rendered == (
-        "- See `task-issue-reading-list` above.\n"
-        "- See `task-issue-notes` above — triggers apply to this call too.\n"
+        '- See `<reading anchor="task-issue">` above.\n'
+        '- See `<notes anchor="task-issue">` above — '
+        "triggers apply to this call too.\n"
         "- If the anchor body is no longer in context, rerun this command "
         "with `--raw` to re-emit it.\n"
     )
 
 
 def test_render_cache_hit_reference_without_notes_anchor() -> None:
-    rendered = render_cache_hit_reference("spike-issue-reading-list")
+    rendered = render_cache_hit_reference("spike-issue")
 
     assert rendered == (
-        "- See `spike-issue-reading-list` above.\n"
+        '- See `<reading anchor="spike-issue">` above.\n'
         "- If the anchor body is no longer in context, rerun this command "
         "with `--raw` to re-emit it.\n"
     )
@@ -407,10 +408,8 @@ def test_render_cache_hit_reference_includes_raw_recovery_hint() -> None:
     body has dropped out of context.
     """
 
-    with_notes = render_cache_hit_reference(
-        "task-issue-reading-list", "task-issue-notes"
-    )
-    without_notes = render_cache_hit_reference("spike-issue-reading-list")
+    with_notes = render_cache_hit_reference("task-issue", "task-issue")
+    without_notes = render_cache_hit_reference("spike-issue")
 
     assert "`--raw`" in with_notes
     assert "`--raw`" in without_notes
@@ -464,11 +463,11 @@ def test_main_first_call_emits_sections_and_persists(
 
     assert exit_code == 0
     out = capsys.readouterr().out
-    assert "## task-issue-reading-list" in out
-    assert "## task-issue-notes" in out
+    assert '<reading anchor="task-issue">' in out
+    assert '<notes anchor="task-issue">' in out
 
     entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue-reading-list"
+        tmp_path, runtime, session_id, "task-issue"
     )
     assert entry is not None
     assert entry["key"] == {
@@ -478,7 +477,7 @@ def test_main_first_call_emits_sections_and_persists(
         "scope": "content",
     }
     assert entry["body"]
-    assert entry["body"][0] == "## task-issue-reading-list"
+    assert entry["body"][0] == '<reading anchor="task-issue">'
     assert entry["emitted_at"]
 
 
@@ -496,8 +495,9 @@ def test_main_repeat_call_emits_bullet_only_form(
     assert exit_code == 0
     out = capsys.readouterr().out
     assert out == (
-        "- See `task-issue-reading-list` above.\n"
-        "- See `task-issue-notes` above — triggers apply to this call too.\n"
+        '- See `<reading anchor="task-issue">` above.\n'
+        '- See `<notes anchor="task-issue">` above — '
+        "triggers apply to this call too.\n"
         "- If the anchor body is no longer in context, rerun this command "
         "with `--raw` to re-emit it.\n"
     )
@@ -516,7 +516,7 @@ def test_main_repeat_call_for_noteless_type_omits_notes_bullet(
     out = capsys.readouterr().out
 
     assert out == (
-        "- See `spike-issue-reading-list` above.\n"
+        '- See `<reading anchor="spike-issue">` above.\n'
         "- If the anchor body is no longer in context, rerun this command "
         "with `--raw` to re-emit it.\n"
     )
@@ -533,15 +533,15 @@ def test_main_raw_flag_forces_section_emission(
     authoring_resolver_main(base)
     capsys.readouterr()
     first_entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue-reading-list"
+        tmp_path, runtime, session_id, "task-issue"
     )
 
     authoring_resolver_main(base + ["--raw"])
     out = capsys.readouterr().out
 
-    assert "## task-issue-reading-list" in out
+    assert '<reading anchor="task-issue">' in out
     second_entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue-reading-list"
+        tmp_path, runtime, session_id, "task-issue"
     )
     assert first_entry is not None
     assert second_entry is not None
@@ -562,9 +562,9 @@ def test_main_provider_drift_triggers_refresh(
     authoring_resolver_main(_resolver_args(tmp_path, provider="jira"))
     out = capsys.readouterr().out
 
-    assert "## task-issue-reading-list" in out
+    assert '<reading anchor="task-issue">' in out
     entry = read_authoring_resolution(
-        tmp_path, runtime, session_id, "task-issue-reading-list"
+        tmp_path, runtime, session_id, "task-issue"
     )
     assert entry is not None
     assert entry["key"]["provider"] == "jira"
@@ -583,7 +583,7 @@ def test_main_without_session_emits_sections_without_persisting(
 
     assert exit_code == 0
     out = capsys.readouterr().out
-    assert "## task-issue-reading-list" in out
+    assert '<reading anchor="task-issue">' in out
 
     hook_state_dir = tmp_path / ".workflow-cache" / "hook-state"
     if hook_state_dir.exists():

--- a/plugins/workflow/tests/test_workflow_hook.py
+++ b/plugins/workflow/tests/test_workflow_hook.py
@@ -20,7 +20,10 @@ if str(_HOOK_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOK_SCRIPTS_DIR))
 
 import workflow_hook  # noqa: E402
-from workflow_main_context import render as render_template  # noqa: E402
+from workflow_main_context import (  # noqa: E402
+    _merge_runbook_blocks,
+    render as render_template,
+)
 from workflow_command import CommandRequest, CommandResult  # noqa: E402
 from issue.github.cache import GitHubIssueCache  # noqa: E402
 from workflow_github import DEFAULT_ISSUE_FIELDS, GitHubRepository  # noqa: E402
@@ -94,6 +97,10 @@ def _composed_snippet(group: str, provider: str) -> str:
     return extras_path.read_text(encoding="utf-8").strip()
 
 
+def _wrap_policy(text: str) -> str:
+    return f"<policy>\n{text.strip()}\n</policy>"
+
+
 def expected_session_start_context(
     *,
     runtime: str,
@@ -106,12 +113,13 @@ def expected_session_start_context(
         launcher_block = launcher_block.replace(
             "{{WORKFLOW_PLUGIN_ROOT}}", str(_PLUGIN_ROOT)
         )
-    return render_template(text, {
+    rendered = render_template(text, {
         "SNIPPET_LAUNCHER": launcher_block,
         "SNIPPET_AUTHORING": main_context_fragment("snippets/authoring.md"),
         "WORKFLOW_RUNBOOK_DIR": str(runbook_dir),
         "WORKFLOW_ISSUE_PROVIDER": issue_kind,
     })
+    return _wrap_policy(rendered)
 
 
 def expected_subagent_start_context(
@@ -134,6 +142,7 @@ def expected_subagent_start_context(
         "WORKFLOW_ISSUE_PROVIDER": issue_kind,
     })
     agent_name = (agent_type or "").rsplit(":", 1)[-1].strip().lower() if agent_type else ""
+    agent_block = ""
     if agent_name == "issue-implementer":
         template = main_context_fragment("subagent/agents/issue-implementer.md")
         agent_block = render_template(template, {
@@ -141,8 +150,8 @@ def expected_subagent_start_context(
             "WORKFLOW_RUNBOOK_DIR": str(runbook_dir),
             "WORKFLOW_ISSUE_PROVIDER": issue_kind,
         })
-        rendered = f"{rendered}\n\n{agent_block}"
-    return rendered
+    merged = _merge_runbook_blocks(rendered, agent_block)
+    return _wrap_policy(merged)
 
 
 def default_github_relationship_response(request: CommandRequest) -> CommandResult | None:
@@ -1024,7 +1033,13 @@ def test_session_start_injects_policy_for_configured_project(
         runtime=runtime, issue_kind="github"
     )
     runbook_dir = _PLUGIN_ROOT / "authoring" / "runbook"
-    assert "## workflow policy" in context
+    assert "<policy>" in context
+    assert "</policy>" in context
+    assert "<launcher>" in context
+    assert "<authoring-resolver>" in context
+    assert "<runbook>" in context
+    assert "<bash>" in context
+    assert "## workflow policy" not in context
     if runtime == "claude":
         assert "workflow <script>" in context
     else:
@@ -1209,7 +1224,9 @@ def test_session_start_discovers_config_from_nested_project_path(
 
     payload = json.loads(out)
     context = payload["hookSpecificOutput"]["additionalContext"]
-    assert "## workflow policy" in context
+    assert "<policy>" in context
+    assert "<launcher>" in context
+    assert "## workflow policy" not in context
     assert f"\"{_PLUGIN_ROOT}/scripts/workflow\" <script>.py" in context
 
 
@@ -1397,10 +1414,92 @@ def test_claude_subagent_start_injects_issue_implementer_agent_block(
     assert context == expected_subagent_start_context(
         issue_kind="github", agent_type="workflow:issue-implementer"
     )
-    assert "## issue-implementer subagent context" in context
-    assert "issue new" in context
-    assert "issue link" in context
-    assert "issue update" in context
+    assert "<commit-prefix>" in context
+    assert "## issue-implementer subagent context" not in context
+    assert "issue-new" in context
+    assert "issue-link" in context
+    assert "issue-update" in context
+
+
+def test_subagent_start_emits_single_runbook_for_issue_implementer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_config(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_PLUGIN_ROOT))
+
+    captured = io.StringIO()
+    assert claude_main(
+        payload={
+            "session_id": "claude-session-impl-single-runbook",
+            "transcript_path": "/tmp/transcript.jsonl",
+            "cwd": str(tmp_path),
+            "hook_event_name": "SubagentStart",
+            "agent_id": "agent-impl-single",
+            "agent_type": "workflow:issue-implementer",
+        },
+        stdout=captured,
+    ) == 0
+
+    payload = json.loads(captured.getvalue())
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert context.count("<runbook>") == 1
+    assert context.count("</runbook>") == 1
+    for intent in (
+        "issue-fetch",
+        "issue-write",
+        "issue-new",
+        "issue-link",
+        "issue-update",
+        "issue-state",
+    ):
+        assert f"`{intent}`" in context
+
+
+def test_subagent_start_emits_single_runbook_for_generic_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_config(tmp_path)
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(_PLUGIN_ROOT))
+
+    captured = io.StringIO()
+    assert claude_main(
+        payload={
+            "session_id": "claude-session-generic-runbook",
+            "transcript_path": "/tmp/transcript.jsonl",
+            "cwd": str(tmp_path),
+            "hook_event_name": "SubagentStart",
+            "agent_id": "agent-generic",
+            "agent_type": "general-purpose",
+        },
+        stdout=captured,
+    ) == 0
+
+    payload = json.loads(captured.getvalue())
+    context = payload["hookSpecificOutput"]["additionalContext"]
+    assert context.count("<runbook>") == 1
+    assert context.count("</runbook>") == 1
+    assert "issue-fetch" in context
+    for intent in ("issue-write", "issue-new", "issue-link", "issue-update", "issue-state"):
+        assert intent not in context
+
+
+def test_merge_runbook_blocks_drops_empty_runbook() -> None:
+    base = (
+        "<launcher>\nlauncher body\n</launcher>\n\n"
+        "<runbook>\nbase runbook body\n</runbook>"
+    )
+    per_agent = "<commit-prefix>\ncommit-prefix body\n</commit-prefix>\n\n<runbook>\n   \n</runbook>"
+
+    merged = _merge_runbook_blocks(base, per_agent)
+
+    assert "<runbook>" not in merged
+    assert "</runbook>" not in merged
+    assert "<commit-prefix>" in merged
+    assert "<launcher>" in merged
 
 
 def test_claude_subagent_start_emits_nothing_for_non_workflow_projects(

--- a/plugins/workflow/tests/test_workflow_session_state.py
+++ b/plugins/workflow/tests/test_workflow_session_state.py
@@ -83,26 +83,59 @@ def test_subagent_start_records_survive_concurrent_parent_state_updates(
 
 def test_record_and_read_authoring_resolution_round_trip(tmp_path: Path) -> None:
     key = {"type": "task", "role": "issue", "provider": "github", "scope": "content"}
-    body = ["## task-issue-reading-list", "- /abs/path"]
 
     assert record_authoring_resolution(
         tmp_path,
         "claude",
         "sess-1",
-        anchor="task-issue-reading-list",
+        tag="reading",
+        anchor="task-issue",
         key=key,
-        body=body,
         emitted_at="2026-05-21T00:00:00+00:00",
     )
 
     entry = read_authoring_resolution(
-        tmp_path, "claude", "sess-1", "task-issue-reading-list"
+        tmp_path, "claude", "sess-1", tag="reading", anchor="task-issue"
     )
 
     assert entry is not None
     assert entry["key"] == key
-    assert entry["body"] == body
     assert entry["emitted_at"] == "2026-05-21T00:00:00+00:00"
+
+
+def test_record_authoring_resolution_separates_tags(tmp_path: Path) -> None:
+    key = {"type": "task", "role": "issue", "provider": "github", "scope": "content"}
+
+    assert record_authoring_resolution(
+        tmp_path,
+        "claude",
+        "sess-1",
+        tag="reading",
+        anchor="task-issue",
+        key=key,
+        emitted_at="2026-05-21T00:00:00+00:00",
+    )
+    assert record_authoring_resolution(
+        tmp_path,
+        "claude",
+        "sess-1",
+        tag="notes",
+        anchor="task-issue",
+        key=key,
+        emitted_at="2026-05-21T00:00:01+00:00",
+    )
+
+    reading_entry = read_authoring_resolution(
+        tmp_path, "claude", "sess-1", tag="reading", anchor="task-issue"
+    )
+    notes_entry = read_authoring_resolution(
+        tmp_path, "claude", "sess-1", tag="notes", anchor="task-issue"
+    )
+
+    assert reading_entry is not None
+    assert notes_entry is not None
+    assert reading_entry["emitted_at"] == "2026-05-21T00:00:00+00:00"
+    assert notes_entry["emitted_at"] == "2026-05-21T00:00:01+00:00"
 
 
 def test_record_authoring_resolution_overwrites_existing_entry(tmp_path: Path) -> None:
@@ -110,28 +143,27 @@ def test_record_authoring_resolution_overwrites_existing_entry(tmp_path: Path) -
         tmp_path,
         "claude",
         "sess-1",
-        anchor="task-issue-reading-list",
+        tag="reading",
+        anchor="task-issue",
         key={"type": "task", "role": "issue", "provider": "github", "scope": "content"},
-        body=["v1"],
         emitted_at="2026-05-21T00:00:00+00:00",
     )
     record_authoring_resolution(
         tmp_path,
         "claude",
         "sess-1",
-        anchor="task-issue-reading-list",
+        tag="reading",
+        anchor="task-issue",
         key={"type": "task", "role": "issue", "provider": "jira", "scope": "content"},
-        body=["v2"],
         emitted_at="2026-05-21T00:01:00+00:00",
     )
 
     entry = read_authoring_resolution(
-        tmp_path, "claude", "sess-1", "task-issue-reading-list"
+        tmp_path, "claude", "sess-1", tag="reading", anchor="task-issue"
     )
 
     assert entry is not None
     assert entry["key"]["provider"] == "jira"
-    assert entry["body"] == ["v2"]
     assert entry["emitted_at"] == "2026-05-21T00:01:00+00:00"
 
 
@@ -140,14 +172,14 @@ def test_record_authoring_resolution_handles_null_provider(tmp_path: Path) -> No
         tmp_path,
         "claude",
         "sess-1",
-        anchor="spike-issue-reading-list",
+        tag="reading",
+        anchor="spike-issue",
         key={"type": "spike", "role": "issue", "provider": None, "scope": "content"},
-        body=["## spike-issue-reading-list"],
         emitted_at="2026-05-21T00:00:00+00:00",
     )
 
     entry = read_authoring_resolution(
-        tmp_path, "claude", "sess-1", "spike-issue-reading-list"
+        tmp_path, "claude", "sess-1", tag="reading", anchor="spike-issue"
     )
 
     assert entry is not None
@@ -157,7 +189,7 @@ def test_record_authoring_resolution_handles_null_provider(tmp_path: Path) -> No
 def test_read_authoring_resolution_returns_none_when_absent(tmp_path: Path) -> None:
     assert (
         read_authoring_resolution(
-            tmp_path, "claude", "sess-1", "task-issue-reading-list"
+            tmp_path, "claude", "sess-1", tag="reading", anchor="task-issue"
         )
         is None
     )
@@ -189,6 +221,7 @@ def test_authoring_resolutions_survive_concurrent_recorders(tmp_path: Path) -> N
                 "    project,",
                 "    'codex',",
                 "    'parent-session',",
+                "    tag='reading',",
                 "    anchor=anchor,",
                 "    key={",
                 "        'type': anchor.split('-')[0],",
@@ -196,7 +229,6 @@ def test_authoring_resolutions_survive_concurrent_recorders(tmp_path: Path) -> N
                 "        'provider': 'github',",
                 "        'scope': 'content',",
                 "    },",
-                "    body=[f'## {anchor}'],",
                 "    emitted_at='2026-05-21T00:00:00+00:00',",
                 ")",
                 "raise SystemExit(0 if ok else 1)",
@@ -206,7 +238,7 @@ def test_authoring_resolutions_survive_concurrent_recorders(tmp_path: Path) -> N
         encoding="utf-8",
     )
 
-    expected_anchors = {f"a{index:02d}-issue-reading-list" for index in range(8)}
+    expected_anchors = {f"a{index:02d}-issue" for index in range(8)}
     processes = [
         subprocess.Popen(
             [sys.executable, str(recorder), str(tmp_path), str(start_file), anchor],
@@ -224,7 +256,7 @@ def test_authoring_resolutions_survive_concurrent_recorders(tmp_path: Path) -> N
 
     for anchor in expected_anchors:
         entry = read_authoring_resolution(
-            tmp_path, "codex", "parent-session", anchor
+            tmp_path, "codex", "parent-session", tag="reading", anchor=anchor
         )
         assert entry is not None, anchor
-        assert entry["body"] == [f"## {anchor}"]
+        assert entry["key"]["type"] == anchor.split("-")[0]

--- a/plugins/workflow/tests/test_workflow_setup.py
+++ b/plugins/workflow/tests/test_workflow_setup.py
@@ -21,6 +21,10 @@ import workflow_setup  # noqa: E402
 from workflow_command import CommandRequest, CommandResult  # noqa: E402
 from workflow_config import WorkflowConfigError, parse_workflow_config  # noqa: E402
 from workflow_setup import (  # noqa: E402
+    AGENTS_FILENAME,
+    AGENTS_KNOWLEDGE_HEADING,
+    CLAUDE_AGENTS_SHIM,
+    CLAUDE_FILENAME,
     WorkflowSetupError,
     build_config,
     build_config_payload,
@@ -845,6 +849,77 @@ def test_write_is_atomic_when_replace_fails(tmp_path: Path, monkeypatch: pytest.
     assert not list(config_dir.glob("*.tmp"))
 
 
+def test_write_creates_agents_md_with_knowledge_root(tmp_path: Path) -> None:
+    raw = _github_github_config(tmp_path)
+
+    result = write_config(tmp_path, raw)
+
+    agents_path = tmp_path / AGENTS_FILENAME
+    claude_path = tmp_path / CLAUDE_FILENAME
+    agents_text = agents_path.read_text(encoding="utf-8")
+    expected_absolute = str((tmp_path / "wiki" / "workflow").resolve())
+
+    assert AGENTS_KNOWLEDGE_HEADING in agents_text
+    assert "`wiki/workflow`" in agents_text
+    assert expected_absolute in agents_text
+    assert claude_path.read_text(encoding="utf-8") == CLAUDE_AGENTS_SHIM
+    assert result["agents_md"]["agents_action"] == "create"
+    assert result["agents_md"]["claude_action"] == "create"
+    assert result["agents_md"]["knowledge_root"] == {
+        "repo_relative": "wiki/workflow",
+        "absolute": expected_absolute,
+    }
+
+
+def test_write_appends_knowledge_root_when_agents_md_exists(tmp_path: Path) -> None:
+    agents_path = tmp_path / AGENTS_FILENAME
+    original = "# Project Agents\n\nExisting prose.\n"
+    agents_path.write_text(original, encoding="utf-8")
+    claude_path = tmp_path / CLAUDE_FILENAME
+    claude_path.write_text("custom CLAUDE shim\n", encoding="utf-8")
+
+    raw = _github_github_config(tmp_path)
+    result = write_config(tmp_path, raw)
+
+    agents_text = agents_path.read_text(encoding="utf-8")
+    assert agents_text.startswith(original)
+    assert AGENTS_KNOWLEDGE_HEADING in agents_text
+    assert claude_path.read_text(encoding="utf-8") == "custom CLAUDE shim\n"
+    assert result["agents_md"]["agents_action"] == "append"
+    assert result["agents_md"]["claude_action"] == "skip"
+
+
+def test_write_skips_agents_md_when_section_already_present(tmp_path: Path) -> None:
+    agents_path = tmp_path / AGENTS_FILENAME
+    existing = (
+        f"# Project Agents\n\n{AGENTS_KNOWLEDGE_HEADING}\n\nStale entry.\n"
+    )
+    agents_path.write_text(existing, encoding="utf-8")
+
+    raw = _github_github_config(tmp_path)
+    result = write_config(tmp_path, raw)
+
+    assert agents_path.read_text(encoding="utf-8") == existing
+    assert result["agents_md"]["agents_action"] == "skip"
+
+
+def test_write_omits_agents_md_update_when_knowledge_path_absent(
+    tmp_path: Path,
+) -> None:
+    raw = build_config(
+        project=tmp_path,
+        issue_provider="filesystem",
+        knowledge_provider="github",
+        commit_refs_enabled=False,
+    )
+
+    result = write_config(tmp_path, raw)
+
+    assert "agents_md" not in result
+    assert not (tmp_path / AGENTS_FILENAME).exists()
+    assert not (tmp_path / CLAUDE_FILENAME).exists()
+
+
 def test_probe_git_remote_detects_github_repository(tmp_path: Path) -> None:
     def runner(request: CommandRequest) -> CommandResult:
         assert request.args == ("git", "remote", "get-url", "origin")
@@ -902,7 +977,6 @@ def test_build_config_supports_distinct_github_issue_and_wiki_hosts(tmp_path: Pa
         "kind": "github",
         "repo": "enterprise/wiki",
         "host": "github.enterprise.test",
-        "path": "wiki/workflow",
     }
 
 


### PR DESCRIPTION
## Summary

Wrap workflow hook-injected context in XML-style tag blocks (`<policy>`, `<launcher>`, `<authoring-resolver>`, `<commit-prefix>`, `<runbook>`, `<bash>`) so block boundaries are explicit instead of resting on Markdown headings, and move the three `issue-implementer`-specific procedural sections from the per-agent SubagentStart injection block into the agent body. The agent body now refers to injected blocks by tag name and owns the publish / link / writeback procedures, so it stays self-contained for blocker recovery and handoff verbs.

## Changes

- `hooks/context/main/session-start.md`, `hooks/context/subagent/session-start.md`, `hooks/context/subagent/agents/issue-implementer.md`, `hooks/context/snippets/authoring.md`, `hooks/context/snippets/commit-prefix.md`: strip block-name headings; wrap inner content in tag blocks.
- `scripts/workflow_main_context.py`: wrap each rendered payload in a single `<policy>...</policy>` and add `_merge_runbook_blocks` to strip the base subagent's `<runbook>` when the per-agent block ships its own, plus drop any empty-body `<runbook>` from the merged text.
- `agents/issue-implementer.md`: rewrite `## Workflow policy and launcher` to refer to injected tags; add `## Publish / link / writeback procedures` with three subsections; replace `<intent>/<provider>.md of the runbook` and `SubagentStart-injected ... block` references with the new tag / in-body forms.
- `tests/test_workflow_hook.py`: update helpers and inline assertions for the new tag wrappers; add three tests for the runbook-merge behavior (issue-implementer single runbook, generic agent single runbook, empty-tag guard).

## AC verification

- AC1 main `<policy>` + inner tags + `<bash>` for resolver: assertions in `test_session_start_injects_policy_for_configured_project` (`<policy>`, `<launcher>`, `<authoring-resolver>`, `<runbook>`, `<bash>` present; `## workflow policy` absent).
- AC2 generic-agent SubagentStart single `<runbook>` carrying only `issue-fetch`: `test_subagent_start_emits_single_runbook_for_generic_agent` (`<runbook>` count == 1; write-side intents absent).
- AC3 issue-implementer SubagentStart wraps in `<policy>` with `<launcher>`, `<authoring-resolver>`, `<commit-prefix>`, single `<runbook>` of 6 intents: `test_subagent_start_emits_single_runbook_for_issue_implementer` plus updated `test_claude_subagent_start_injects_issue_implementer_agent_block`.
- AC4 no removed `##` headings remain: `not in context` guards in the updated session-start and subagent-start tests.
- AC5 `agents/issue-implementer.md` gets the new procedures section and stops indirecting through the SubagentStart block: verified by inspection (`grep -n` returns no `of the runbook`, no `SubagentStart-injected`, no `issue-implementer subagent context`; new `## Publish / link / writeback procedures` section present with three subsections).
- AC6 runbook references use the new `<runbook>`'s `<intent>` form: verified by inspection (all five flagged occurrences rewritten).
- AC7 full suite plus three new tests pass: `uv run --with pytest --with python-frontmatter --with PyYAML pytest plugins/workflow/tests` reports 496 passed.

Closes #141