### PR TITLE
Reject custom issue types on Jira without explicit mapping

### DIFF
--- a/plugins/spectrack/.claude-plugin/plugin.json
+++ b/plugins/spectrack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spectrack",
   "displayName": "SpecTrack",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/spectrack/.codex-plugin/plugin.json
+++ b/plugins/spectrack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrack",
-  "version": "0.16.17",
+  "version": "0.16.18",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/spectrack/hooks/context/snippets/authoring.md
+++ b/plugins/spectrack/hooks/context/snippets/authoring.md
@@ -47,9 +47,10 @@ flow. If `--type` is not one of SpecTrack's workflow artifact types
 below, the resolver returns `NONE`: there is no authoring contract to
 read, so create the artifact directly. How a non-workflow type is
 recorded is provider-specific — GitHub carries it as a type label, Jira
-maps it to a native issue type (falling back to the project's default
-issue type when the name has no mapping) — so pass the requested type
-through and let the backend resolve it (`spectrack issue <verb> --help`).
+maps it to a native issue type — so pass the requested type through. On
+Jira a name with no configured mapping falls back to the site's default
+`issue_type` (and errors when none is set), so set `--issue-type`
+explicitly when needed (`spectrack issue <verb> --help`).
 
 Types:
 

--- a/plugins/spectrack/hooks/context/snippets/authoring.md
+++ b/plugins/spectrack/hooks/context/snippets/authoring.md
@@ -43,8 +43,10 @@ spectrack mustread \
 
 The resolver returns markdown listing files to read before drafting.
 Treat any bullet in a notes section as a binding rule for the calling
-flow. If the target is not a workflow artifact, the resolver returns
-`NONE`.
+flow. If `--type` is not one of SpecTrack's workflow artifact types
+below, the resolver returns `NONE`: there is no authoring contract to
+read, so create the artifact directly with whatever type the user asked
+for.
 
 Types:
 

--- a/plugins/spectrack/hooks/context/snippets/authoring.md
+++ b/plugins/spectrack/hooks/context/snippets/authoring.md
@@ -45,12 +45,12 @@ The resolver returns markdown listing files to read before drafting.
 Treat any bullet in a notes section as a binding rule for the calling
 flow. If `--type` is not one of SpecTrack's workflow artifact types
 below, the resolver returns `NONE`: there is no authoring contract to
-read, so create the artifact directly. How a non-workflow type is
-recorded is provider-specific — GitHub carries it as a type label, Jira
-maps it to a native issue type — so pass the requested type through. On
-Jira a name with no configured mapping falls back to the site's default
-`issue_type` (and errors when none is set), so set `--issue-type`
-explicitly when needed (`spectrack issue <verb> --help`).
+read. A non-workflow type is a GitHub-only capability: GitHub carries it
+as a type label, so create the issue directly with the requested type.
+Jira represents the type as a native issue type and rejects any it cannot
+map, so on Jira use only the workflow types below — or first add a
+`providers.issues.artifact_issue_types` mapping (see `spectrack issue
+<verb> --help`).
 
 Types:
 

--- a/plugins/spectrack/hooks/context/snippets/authoring.md
+++ b/plugins/spectrack/hooks/context/snippets/authoring.md
@@ -45,8 +45,11 @@ The resolver returns markdown listing files to read before drafting.
 Treat any bullet in a notes section as a binding rule for the calling
 flow. If `--type` is not one of SpecTrack's workflow artifact types
 below, the resolver returns `NONE`: there is no authoring contract to
-read, so create the artifact directly with whatever type the user asked
-for.
+read, so create the artifact directly. How a non-workflow type is
+recorded is provider-specific — GitHub carries it as a type label, Jira
+maps it to a native issue type (falling back to the project's default
+issue type when the name has no mapping) — so pass the requested type
+through and let the backend resolve it (`spectrack issue <verb> --help`).
 
 Types:
 

--- a/plugins/spectrack/scripts/issue/jira/backend.py
+++ b/plugins/spectrack/scripts/issue/jira/backend.py
@@ -911,6 +911,23 @@ class JiraIssueBackend:
         normalized_issue_type = _optional_text(issue_type)
         normalized_epic_name = _optional_text(epic_name)
 
+        # Jira represents the workflow type as a native issuetype, not a label,
+        # so a type it cannot map has nowhere to live and would silently
+        # collapse into the site default. Custom (non-workflow) types are a
+        # GitHub-only capability: reject one here unless the caller pins a
+        # native issuetype with --issue-type or maps it in config. Mirrors the
+        # set-type guard.
+        if normalized_issue_type is None and not _jira_native_issue_type(
+            config, artifact_type
+        ):
+            artifact = artifact_type.strip().lower()
+            raise IssueBackendError(
+                f"Jira does not support the custom issue type '{artifact_type}'. "
+                f"Use a SpecTrack workflow type, add a "
+                f"providers.issues.artifact_issue_types.{artifact} mapping in "
+                f".spectrack/config.yml, or pass --issue-type."
+            )
+
         body_path = body_file.expanduser()
         if not body_path.is_file():
             raise IssueBackendError(f"body file does not exist: {body_path}")
@@ -1601,14 +1618,9 @@ class JiraIssueBackend:
         elif verb == "set-type":
             if not new_type or not new_type.strip():
                 raise IssueBackendError("set-type requires a non-empty type")
-            artifact = new_type.strip().lower()
-            try:
-                settings = _jira_issue_provider_settings(config.root)
-            except Exception as exc:  # noqa: BLE001
-                raise IssueBackendError(str(exc)) from exc
-            configured = _jira_configured_artifact_issue_types(settings).get(artifact)
-            native = configured or JIRA_ARTIFACT_ISSUE_TYPES.get(artifact)
+            native = _jira_native_issue_type(config, new_type)
             if not native:
+                artifact = new_type.strip().lower()
                 raise IssueBackendError(
                     f"no Jira issuetype mapping for workflow type '{new_type}'. "
                     f"Configure providers.issues.artifact_issue_types.{artifact} in .spectrack/config.yml."
@@ -1633,6 +1645,21 @@ class JiraIssueBackend:
             )
         )
         return flatten_provider_envelope(response.payload, project=config.root)
+
+
+def _jira_native_issue_type(config: WorkflowConfig, artifact_type: str) -> str | None:
+    """Resolve the native Jira issuetype an artifact type maps to, if any.
+
+    Returns the configured (``providers.issues.artifact_issue_types.<type>``)
+    or built-in mapping, or ``None`` when the type has no mapping. Jira carries
+    the workflow type as a native issuetype rather than a label, so an unmapped
+    type cannot be expressed — callers reject it instead of letting it collapse
+    into the site default.
+    """
+    artifact = artifact_type.strip().lower()
+    settings = _jira_issue_provider_settings(config.root)
+    configured = _jira_configured_artifact_issue_types(settings).get(artifact)
+    return configured or JIRA_ARTIFACT_ISSUE_TYPES.get(artifact)
 
 
 def _strip_body_frontmatter(body: str) -> str:

--- a/plugins/spectrack/scripts/mustread.py
+++ b/plugins/spectrack/scripts/mustread.py
@@ -585,6 +585,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    # Types outside SpecTrack's built-in workflow vocabulary carry no authoring
+    # contract. Report NONE (rather than failing) so the calling flow knows
+    # there is nothing to read and can create the artifact directly.
+    if args.type not in ALL_TYPES:
+        print("NONE")
+        return 0
+
     try:
         resolution = resolve_authoring(
             args.type,

--- a/plugins/spectrack/tests/test_cache_issue_drafts.py
+++ b/plugins/spectrack/tests/test_cache_issue_drafts.py
@@ -1234,6 +1234,93 @@ def test_jira_publish_creates_issue_inline_and_deletes_body_file(tmp_path: Path)
     assert runner.requests[0].args == _jira_write_args()
 
 
+def test_jira_publish_rejects_custom_non_workflow_type(tmp_path: Path) -> None:
+    # Jira maps the workflow type to a native issuetype, so a custom type it
+    # cannot map is unsupported: publish must reject it (not silently fall back
+    # to the site default) and touch the provider for nothing.
+    _write_jira_config(tmp_path)
+    body_file = _write_body_file(tmp_path, "Body.\n")
+
+    runner = JiraFakeRunner({})
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    code = jira_issue_drafts_main(
+        [
+            "--project",
+            str(tmp_path),
+            "publish",
+            "--type",
+            "customthing",
+            "--title",
+            "Published Jira issue",
+            "--body-file",
+            str(body_file),
+        ],
+        stdout=stdout,
+        stderr=stderr,
+        runner=runner,
+    )
+
+    assert code == 2
+    assert "does not support the custom issue type 'customthing'" in stderr.getvalue()
+    assert runner.requests == []
+    assert body_file.exists()
+    assert stdout.getvalue() == ""
+
+
+def test_jira_publish_allows_custom_type_with_explicit_issue_type(tmp_path: Path) -> None:
+    # An explicit --issue-type pins a native issuetype, so a non-workflow type
+    # is allowed through that deliberate escape hatch.
+    _write_jira_config(tmp_path)
+    body_file = _write_body_file(tmp_path, "Body.\n")
+    issue_url = "https://jira.example.test/rest/api/2/issue/TEST-1234"
+    remote_links_url = "https://jira.example.test/rest/api/2/issue/TEST-1234/remotelink"
+
+    runner = JiraFakeRunner(
+        {
+            _jira_write_args(): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps({"id": "10001", "key": "TEST-1234"}),
+            ),
+            _jira_curl_get_args(issue_url): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps(_jira_issue_payload()),
+            ),
+            _jira_curl_get_args(remote_links_url): CommandResult(
+                request=CommandRequest(args=()),
+                returncode=0,
+                stdout=json.dumps([]),
+            ),
+        }
+    )
+    stdout = io.StringIO()
+
+    code = jira_issue_drafts_main(
+        [
+            "--project",
+            str(tmp_path),
+            "publish",
+            "--type",
+            "customthing",
+            "--issue-type",
+            "Task",
+            "--title",
+            "Published Jira issue",
+            "--body-file",
+            str(body_file),
+        ],
+        stdout=stdout,
+        runner=runner,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert code == 0
+    assert payload["issue"] == "TEST-1234"
+
+
 def test_jira_publish_fails_fast_when_relationship_mapping_missing(tmp_path: Path) -> None:
     _write_jira_config(tmp_path)
     body_file = _write_body_file(tmp_path, "Body.\n")

--- a/plugins/spectrack/tests/test_mustread.py
+++ b/plugins/spectrack/tests/test_mustread.py
@@ -788,6 +788,24 @@ def test_main_repeat_call_re_emits_full_sections(
     assert second == first
 
 
+@pytest.mark.parametrize("artifact_type", ["customthing", "actors", "story"])
+def test_main_emits_none_for_non_workflow_type(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    artifact_type: str,
+) -> None:
+    # Types outside the built-in workflow vocabulary have no authoring
+    # contract: the CLI reports NONE and succeeds instead of erroring, so the
+    # calling flow can create the artifact directly.
+    exit_code = mustread_main(
+        ["--type", artifact_type, "--provider", "github", "--project", str(tmp_path)]
+    )
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert out.strip() == "NONE"
+
+
 def test_main_without_session_emits_sections(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

This change adds validation to reject custom (non-workflow) issue types when publishing to Jira, unless the user explicitly provides a native issue type mapping via `--issue-type` or configuration. This prevents silent fallback to the site default and improves the user experience by providing clear error messages.

## Key Changes

- **Jira backend validation**: Added a check in `_publish_issue()` that rejects custom artifact types that cannot be mapped to native Jira issue types, mirroring the existing guard in `set-type`
- **Refactored type resolution**: Extracted `_jira_native_issue_type()` helper function to centralize the logic for resolving artifact types to native Jira issue types, used by both `publish` and `set-type` operations
- **Mustread behavior**: Updated `mustread` to return `NONE` for non-workflow types (custom types outside SpecTrack's built-in vocabulary), allowing calling flows to create artifacts directly without an authoring contract
- **Documentation**: Updated authoring guidance to clarify that non-workflow types are GitHub-only and explain the Jira limitation and workarounds
- **Test coverage**: Added two new test cases:
  - `test_jira_publish_rejects_custom_non_workflow_type`: Verifies rejection of unmapped custom types
  - `test_jira_publish_allows_custom_type_with_explicit_issue_type`: Verifies the escape hatch via `--issue-type`
  - `test_main_emits_none_for_non_workflow_type`: Verifies mustread returns `NONE` for non-workflow types
- **Version bump**: Updated plugin versions to 0.16.18

## Implementation Details

The new `_jira_native_issue_type()` function encapsulates the resolution logic: it checks for a configured mapping in `providers.issues.artifact_issue_types.<type>` first, then falls back to the built-in `JIRA_ARTIFACT_ISSUE_TYPES` mapping. This ensures consistent behavior across publish and set-type operations and makes the mapping strategy explicit and testable.

https://claude.ai/code/session_01WKv8nB55xBHdSd3wjaDQvy