### PR TITLE
spectrack: ExitPlanMode deferred-work gate + 0.19.0

### DIFF
--- a/plugins/spectrack/.claude-plugin/plugin.json
+++ b/plugins/spectrack/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spectrack",
   "displayName": "SpecTrack",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/spectrack/.codex-plugin/plugin.json
+++ b/plugins/spectrack/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrack",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "Provider-backed workflow over GitHub Issues, Jira, GitHub repository wiki directory, and Confluence with issue and knowledge authoring contracts",
   "author": {
     "name": "studykit"

--- a/plugins/spectrack/hooks/hooks.json
+++ b/plugins/spectrack/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Workflow hooks. SessionStart persists workflow shell environment exports (and prepends the plugin scripts directory to PATH) when .spectrack/config.yml exists and injects provider-backed workflow authoring policy only for main sessions. SubagentStart injects the workflow launcher contract plus provider-specific issue-fetch usage as additionalContext for the subagent. PreToolUse protects read-only provider cache projections: it blocks edits to issue content files and blocks both reads and edits of the internal .meta.json. UserPromptSubmit reads mentioned GitHub issue references through cache-aware provider reads and injects project-relative issue cache paths as additionalContext.",
+  "description": "Workflow hooks. SessionStart persists workflow shell environment exports (and prepends the plugin scripts directory to PATH) when .spectrack/config.yml exists and injects provider-backed workflow authoring policy only for main sessions. SubagentStart injects the workflow launcher contract plus provider-specific issue-fetch usage as additionalContext for the subagent. PreToolUse protects read-only provider cache projections: it blocks edits to issue content files and blocks both reads and edits of the internal .meta.json; a separate ExitPlanMode prompt hook blocks implementation plans that defer in-scope work or decisions so they are resolved with the user before approval. UserPromptSubmit reads mentioned GitHub issue references through cache-aware provider reads and injects project-relative issue cache paths as additionalContext.",
   "hooks": {
     "PreToolUse": [
       {
@@ -10,6 +10,18 @@
             "command": "uv run --script \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/hook_claude.py\"",
             "timeout": 5,
             "description": "Protect read-only provider cache projections: block edits to issue content files and both reads and edits of the internal .meta.json"
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "You are a plan gate for ExitPlanMode. The hook input JSON is: $ARGUMENTS. Read tool_input.plan, the implementation plan the agent is about to present for approval.\n\nDecide whether the plan defers, postpones, or leaves unresolved any work or decision that the plan itself treats as in scope for this task. Deferral takes many forms, not just literal headings; flag any of: sections such as Open Questions, Deferred, TBD, Later, Follow-up, or Future work; phrases such as 'we can do this later', 'for now', 'leave as-is', 'revisit', 'stub out', or 'placeholder'; either/or choices left for later such as 'option A or B' or 'decide during implementation'; or a required decision handed off instead of made.\n\nAllow (ok true) when the plan resolves everything it scopes in, or when it is a research, investigation, or analysis plan whose deliverable is findings rather than a code change, since such plans legitimately end in open questions.\n\nBlock (ok false) only for implementation plans that carry unresolved in-scope work or decisions. In the reason, name the specific deferred items and instruct the agent to resolve each open question or choice with the user now, fold the decisions into the plan, and re-present a plan with nothing required left deferred.\n\nRespond with ONLY a JSON object: {\"ok\": true} or {\"ok\": false, \"reason\": \"...\"}.",
+            "timeout": 30,
+            "statusMessage": "Checking the plan for deferred work",
+            "description": "Block ExitPlanMode when an implementation plan defers in-scope work or decisions, so the agent resolves them with the user before the plan is approved"
           }
         ]
       }


### PR DESCRIPTION
Two commits on this branch:

1. **ExitPlanMode deferred-work gate** — a Claude-only `PreToolUse` prompt hook (`matcher: "ExitPlanMode"`) in `plugins/spectrack/hooks/hooks.json`. A fast model reads `tool_input.plan` and returns `{ok:false, reason}` to deny the plan when an implementation plan defers in-scope work or decisions (Open Questions / Deferred / TBD sections, "later"/"for now"/stub/placeholder phrasing, unresolved either/or choices), so the agent resolves them with the user before approval. Research/investigation plans (deliverable = findings) pass.
2. **Version bump** `0.18.1 → 0.19.0` in both the Claude and Codex manifests (identical strings, per the shared-runtime version policy).

**No Codex manifest change** for the hook: prompt hooks are a Claude runtime feature and Codex has no plan mode. Per the [hooks reference](https://code.claude.com/docs/en/hooks#prompt-based-hooks), `PreToolUse` supports prompt hooks and maps `ok:false` to `permissionDecision: deny` with the reason surfaced to the model.

**Scope note:** the prompt hook fires on every `ExitPlanMode` in any project where the plugin is enabled — prompt hooks cannot read the filesystem, so it cannot gate on `.spectrack/config.yml` the way the command hooks do. The prompt itself passes research/investigation plans.

Full spectrack suite passes (648 passed); Codex manifest hook config unchanged.