### PR TITLE
#185 guard: arm approval gate on approved non-deferring plan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -131,7 +131,7 @@
     {
       "name": "guard",
       "source": "./plugins/guard",
-      "description": "Enforce evidence-backed technical claims and gate file edits behind explicit user approval. Ships a Grounded output style, logs each session's turns with the assistant's claims and their evidence, audits a turn for grounding on demand (/guard:audit) or automatically each turn in subagent/headless mode, and denies file-mutating tools until the user explicitly approves implementation. Claude Code only.",
+      "description": "Enforce evidence-backed technical claims and gate file edits behind explicit user approval. Ships a Grounded output style, logs each session's turns with the assistant's claims and their evidence, audits a turn for grounding on demand (/guard:audit) or automatically each turn in subagent/headless mode, and denies file-mutating tools until the user explicitly approves implementation — in a message or by approving a non-deferring plan in plan mode. Claude Code only.",
       "author": {
         "name": "studykit"
       },

--- a/plugins/guard/.claude-plugin/plugin.json
+++ b/plugins/guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "guard",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Enforce evidence-backed technical claims in Claude Code. Ships a Grounded output style, logs each session's user/assistant turns with the assistant's claims and their supporting evidence, and (on demand via /guard:audit by default, or automatically each turn in subagent/headless mode) audits a turn for grounding — dispatching the guardian subagent or an isolated headless judge that blocks. Claude Code only.",
   "author": {
     "name": "studykit"

--- a/plugins/guard/AGENTS.md
+++ b/plugins/guard/AGENTS.md
@@ -11,7 +11,9 @@ no Codex path):
    hook injects `additionalContext` with no block; the main agent dispatches the
    `guardian` subagent to run the same audit), or `headless` (an isolated `claude` runs
    inside the Stop hook and **blocks** on a violation).
-2. **Approval gate** — block file mutation until the user explicitly approves.
+2. **Approval gate** — block file mutation until the user explicitly approves. Approval
+   arms on a user message (classifier) or on the user approving a non-deferring plan via
+   ExitPlanMode (`PostToolUse` → `plan-approved`); the model can arm neither.
 
 A **turn is the transcript's `promptId`.** guard keeps no turn buffer; at Stop it
 slices the turn from Claude Code's transcript (`transcript_path` + `prompt_id`). State

--- a/plugins/guard/README.md
+++ b/plugins/guard/README.md
@@ -120,6 +120,11 @@ your own words — for example "go ahead", "implement it", or "apply the change"
 guard reads your message together with the recent conversation, so a short
 "go ahead" counts when it clearly accepts a proposed plan — and doesn't when it
 refers to something else.
+Approving a **plan in plan mode** also counts as approval — as long as the plan leaves
+no in-scope work deferred (no "TBD", "later", or unresolved either/or choices). Approve
+a plan that still defers work and the gate stays closed until you approve in your own
+words, so you are never handed the keys on a half-finished plan.
+
 Approval sticks with the current task: questions, refinements, corrections, and
 follow-ups on the same work keep it in place. The gate only re-locks when you clearly
 move on to a different, unrelated task — at which point you approve that one afresh.

--- a/plugins/guard/dev/design.md
+++ b/plugins/guard/dev/design.md
@@ -15,6 +15,7 @@ line-by-line walkthrough.
 | `UserPromptExpansion` (matcher `^(guard:)?mode$`) | `set-mode` | Set session `mode` (`manual`\|`subagent`\|`headless`). |
 | `UserPromptExpansion` (matcher `^(guard:)?audit$`) | `verify` | On demand, dispatch the guardian for the last completed turn (`pending_verify_prompt_id`). |
 | `PreToolUse` (`Write\|Edit\|MultiEdit\|NotebookEdit`) | `gate` | Deny file edits until approved. |
+| `PostToolUse` (matcher `ExitPlanMode`) | `plan-approved` | On plan approval, arm the gate when the plan defers no in-scope work. |
 | (called via Bash, not a hook) | `record-verified` | Guardian appends a passed turn's claims to the verified store. |
 | (called via Bash, not a hook) | `exempt` | `guard:exempt` skill records the user's confirmed `exempt_skills` selection (that key only). |
 | `Stop` | `stop` | manual: record pending target, no audit. subagent: dispatch guardian. headless: in-hook judge that blocks. |
@@ -69,6 +70,16 @@ payloads, not memory.
 - **A Stop hook may inject `additionalContext` without `decision`** and the
   conversation continues — the subagent-dispatch mechanism. `stop_hook_active: true`
   ⇒ guard already blocked this turn, so Stop returns at once.
+- **`PostToolUse(ExitPlanMode)` fires only on plan approval.** Verified against live
+  payloads (probe on Claude Code 2.1.x): approving a plan fires BOTH `PreToolUse` and
+  `PostToolUse`; rejecting it ("Denied by user") fires `PreToolUse` only — consistent
+  with the hooks doc rule that a blocked/denied tool produces no PostToolUse
+  (https://code.claude.com/docs/en/hooks). The plan text rides in `tool_input.plan`
+  on both payloads (and `tool_response.plan` on Post); `prompt_id` is common to both;
+  on approval `permission_mode` transitions `plan → acceptEdits`. This is what lets
+  `cmd_plan_approved` treat its own invocation as a genuine user approval — the model
+  authors the plan but cannot approve its own tool call. Re-verify against a live
+  payload before relying on it.
 - **`/guard:turn` and `/guard:mode` take a `--project` / `--global` scope flag.** No
   flag sets the live session (`toggle` / `set-mode` write `state/`); `--project` writes
   only the session-start default (`enabled` / `mode`) to `guard.local.json`, live
@@ -83,8 +94,15 @@ payloads, not memory.
   non-zero exit. Any judge failure (missing binary, timeout, unparseable output)
   leaves state untouched and does not block — guard must never harass the user
   because its own machinery broke.
-- **Approval is armed only by a user message**, only on an explicit-implementation
-  verdict from the classifier. The `turn` skill and the model cannot arm it. The
+- **Approval is armed only by a user action**, never by the model. Two paths, both
+  requiring the user: (1) a **user message** on an explicit-implementation verdict from
+  the classifier; (2) the user **approving a plan** via ExitPlanMode, where
+  `cmd_plan_approved` (PostToolUse, which fires only on approval — see Verified facts)
+  arms the gate *only if* the approved plan defers no in-scope work (`PLAN_DEFER_SYSTEM`
+  judge). The model authors the plan but cannot approve its own tool call, so path 2 is
+  still a genuine user action; a deferring plan does not arm, and a judge failure never
+  arms (fail toward the closed gate — the opposite of the evidence judge's fail-open).
+  The `turn` skill and the model cannot arm it by either path. The
   classifier sees the tail of the session archive as conversation context
   (`_recent_dialogue`) — used only to resolve what the message refers to, so a bare
   "go ahead" arms only when it answers a proposed plan; context alone can never

--- a/plugins/guard/hooks/hooks.json
+++ b/plugins/guard/hooks/hooks.json
@@ -61,6 +61,19 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/guard_hook.py\" plan-approved",
+            "timeout": 60,
+            "description": "On plan approval, arm the approval gate when the plan defers no in-scope work."
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/guard/scripts/guard_hook.py
+++ b/plugins/guard/scripts/guard_hook.py
@@ -836,6 +836,39 @@ APPROVAL_SCHEMA = {
     "additionalProperties": False,
 }
 
+# Plan-approval gate. When the user APPROVES a plan via ExitPlanMode, PostToolUse
+# fires (verified: a rejected plan fires no PostToolUse), so cmd_plan_approved runs
+# this judge over the approved plan text to decide whether to arm the approval gate.
+# Arm only when the plan resolves everything it scopes in — a plan that still defers
+# in-scope work is not a green light to start editing files.
+PLAN_DEFER_SYSTEM = (
+    "You are a plan gate. You are given an implementation plan the user has just "
+    "approved. Decide whether the plan DEFERS, postpones, or leaves unresolved any "
+    "work or decision that the plan itself treats as in scope for this task.\n\n"
+    "Deferral takes many forms, not just literal headings; treat as deferral any of: "
+    "sections such as Open Questions, Deferred, TBD, Later, Follow-up, or Future work; "
+    "phrases such as 'we can do this later', 'for now', 'leave as-is', 'revisit', "
+    "'stub out', or 'placeholder'; an either/or choice left for later such as "
+    "'option A or B' or 'decide during implementation'; or a required decision handed "
+    "off instead of made. The same applies in any language (including Korean: "
+    "'미정', '추후', '나중에', '확인 필요', '결정 안 됨').\n\n"
+    "Return ok=true when the plan resolves everything it scopes in, OR when it is a "
+    "research, investigation, or analysis plan whose deliverable is findings rather "
+    "than a code change (such plans legitimately end in open questions).\n\n"
+    "Return ok=false ONLY for an implementation plan that carries unresolved in-scope "
+    "work or a deferred decision; in `reason`, name the specific deferred items. "
+    "Return only JSON."
+)
+PLAN_DEFER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ok": {"type": "boolean"},
+        "reason": {"type": "string"},
+    },
+    "required": ["ok", "reason"],
+    "additionalProperties": False,
+}
+
 EVIDENCE_SYSTEM = (
     "You audit an assistant's response from a coding session on TWO axes: unsupported "
     "technical claims (AXIS 1) and unjustified deferrals (AXIS 2), both defined below.\n\n"
@@ -998,6 +1031,69 @@ def cmd_user_prompt() -> int:
         })
     _trace(project_dir, session_id, "user-prompt", "approval",
            approved=state["approved"], before=approved_before)
+    return 0
+
+
+def cmd_plan_approved() -> int:
+    """PostToolUse(ExitPlanMode): the user has APPROVED a plan.
+
+    Verified against real payloads: an ExitPlanMode approval fires PostToolUse, while
+    a rejection ("Denied by user") fires only PreToolUse — so this hook running IS the
+    user's approval, a genuine user action the model cannot forge (it authors the plan
+    but cannot approve its own tool call). That closes the gap where a plan approved in
+    plan mode left no user text message for the UserPromptSubmit classifier to read, so
+    the gate stayed locked and the first post-approval edit was denied.
+
+    Arm the approval gate — but only when the approved plan resolves everything it
+    scopes in. A plan that still defers in-scope work is not a green light to edit, so
+    it leaves the gate as-is (the user can still approve in words later). On any judge
+    failure, do NOT arm: unlike the evidence judge (fail-open = don't block the user),
+    the safe direction for the gate is to stay closed.
+    """
+    project_dir = _project_dir()
+    payload = _read_payload()
+    if payload is None or project_dir is None:
+        return 0
+    session_id = _session_id(payload)
+    if session_id is None:
+        return 0
+
+    config = _load_config(project_dir)
+    state = _read_state(project_dir, session_id, config)
+    if not state["enabled"]:
+        return 0
+
+    # Defensive: the hook matcher already scopes this to ExitPlanMode.
+    if payload.get("tool_name") != "ExitPlanMode":
+        return 0
+    if state["approved"]:
+        return 0  # already armed — no judge spawn, nothing to change
+
+    # The plan text rides in tool_input.plan on the PostToolUse payload (verified).
+    tool_input = payload.get("tool_input")
+    plan_text = tool_input.get("plan") if isinstance(tool_input, dict) else None
+    if not isinstance(plan_text, str) or not plan_text.strip():
+        _trace(project_dir, session_id, "plan-approved", "no_plan_text")
+        return 0
+
+    verdict = run_judge(project_dir, PLAN_DEFER_SYSTEM, plan_text, PLAN_DEFER_SCHEMA, config)
+    if verdict is None:
+        # Fail toward the closed gate: never arm on a judge failure.
+        _trace(project_dir, session_id, "plan-approved", "judge_failed")
+        return 0
+
+    if verdict.get("ok") is True:
+        state["approved"] = True
+        _write_state(project_dir, session_id, state)
+        _append_log(project_dir, session_id, {
+            "role": "gate",
+            "approved": True,
+            "reasoning": "plan approved (no deferred in-scope work): " + verdict.get("reason", ""),
+        })
+        _trace(project_dir, session_id, "plan-approved", "armed")
+    else:
+        _trace(project_dir, session_id, "plan-approved", "defers",
+               reason=str(verdict.get("reason", ""))[:200])
     return 0
 
 
@@ -1805,6 +1901,7 @@ def cmd_exempt() -> int:
 
 SUBCOMMANDS = {
     "user-prompt": cmd_user_prompt,
+    "plan-approved": cmd_plan_approved,
     "toggle": cmd_toggle,
     "set-mode": cmd_set_mode,
     "verify": cmd_verify,


### PR DESCRIPTION
Closes #185.

## What

Adds a `PostToolUse(ExitPlanMode)` hook to guard and a new `plan-approved` subcommand. When the user **approves** a plan whose content **defers no in-scope work**, guard arms its approval gate so the file edits that follow are not blocked.

## Why

guard's gate arms `approved` only from a user text message (`cmd_user_prompt`). Approving a plan in **plan mode** produces no such message, so the gate stayed locked and the first `Write`/`Edit` after approval was denied — friction right after the user said yes.

## How

- New `plan-approved` runs a defer-check judge (`PLAN_DEFER_SYSTEM`) over `tool_input.plan`:
  - resolves everything it scopes in (or is a research/analysis plan) → arm `approved = true`
  - still defers in-scope work/decisions → gate stays closed (status quo)
  - judge failure → never arm (fail toward the closed gate)
- Scope is **guard-only**; spectrack's own ExitPlanMode defer-check is untouched.

## Verified behavior (live payloads, Claude Code 2.1.x)

- Approve a plan → `PostToolUse(ExitPlanMode)` fires; reject ("Denied by user") → only `PreToolUse`. So the hook running is a genuine user approval the model cannot forge.
- Synthetic-payload runs of `plan-approved`: non-deferring plan → `approved: true`; deferring plan → not armed (judge named the deferred items); empty plan / wrong tool → no-op.

Runtime facts checked against https://code.claude.com/docs/en/hooks.

Bumps guard `0.6.0 → 0.7.0`; updates the hook table, invariants, README, and marketplace description.